### PR TITLE
Dynamic import

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,6 @@
         "node": ["6"]
       }
     }]
-  ]
+  ],
+  "plugins": ["babel-plugin-syntax-dynamic-import"]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: 'airbnb',
+  parser: 'babel-eslint',
   plugins: ['jest'],
   env: {
     'jest/globals': true,
@@ -18,6 +19,7 @@ module.exports = {
     'prefer-template': 0,
     'global-require': 0,
     'no-restricted-syntax': 0,
+    'react/no-multi-comp': 0,
   },
 
   globals: {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 enduire
+Copyright (c) 2017 happo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -429,6 +429,30 @@ module.exports {
 };
 ```
 
+### Puppeteer
+
+If you have Happo examples that rely on measuring the DOM, the default
+pre-renderer (JSDOM) might not produce the results you need. By using a real
+browser (Chrome) to pre-render examples, measurements are available on render
+time. See https://github.com/happo/happo-plugin-puppeteer.
+
+```bash
+npm install --save-dev happo-plugin-puppeteer
+```
+
+```js
+const happoPluginPuppeteer = require('happo-plugin-puppeteer');
+
+// .happo.js
+module.exports {
+  // ...
+  plugins: [
+    happoPluginPuppeteer(),
+  ],
+};
+```
+
+
 ## Local development
 
 The `happo dev` command is designed to help local development of components. In

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ component" which you render synchronously in the Happo test.
 ### Storybook
 
 The Happo plugin for [Storybook](https://storybook.js.org/) will automatically
-turn your stories into Happo examples. See https://github.com/enduire/happo-plugin-storybook.
+turn your stories into Happo examples. See https://github.com/happo/happo-plugin-storybook.
 
 ```bash
 npm install --save-dev happo-plugin-storybook
@@ -410,7 +410,7 @@ module.exports {
 ### Gatsby
 
 The Happo plugin for [Gatsby](https://www.gatsbyjs.org/) turns all your
-static pages into Happo tests. See https://github.com/enduire/happo-plugin-gatsby.
+static pages into Happo tests. See https://github.com/happo/happo-plugin-gatsby.
 
 ```bash
 npm install --save-dev happo-plugin-gatsby

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "arrowParens": "always"
   },
   "dependencies": {
+    "babel-plugin-dynamic-import-node": "^2.1.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-react": "^6.24.1",
     "commander": "^2.15.1",
@@ -64,8 +65,10 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^22.4.3",
     "babel-loader": "^7.1.4",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/enduire/happo.io.git"
+    "url": "git+https://github.com/happo/happo.io.git"
   },
   "keywords": [
     "visual",
@@ -29,9 +29,9 @@
   "author": "Henric Trotzig",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/enduire/happo.io/issues"
+    "url": "https://github.com/happo/happo.io/issues"
   },
-  "homepage": "https://github.com/enduire/happo.io#readme",
+  "homepage": "https://github.com/happo/happo.io#readme",
   "jest": {
     "testEnvironment": "node",
     "setupTestFrameworkScriptFile": "./test/jestSetup.js",

--- a/src/createWebpackBundle.js
+++ b/src/createWebpackBundle.js
@@ -23,6 +23,9 @@ function generateBaseConfig({ entry, type, tmpdir }) {
           exclude: /node_modules/,
           use: {
             loader: babelLoader,
+            options: {
+              plugins: [require.resolve('babel-plugin-dynamic-import-node')],
+            },
           },
         },
       ],
@@ -42,7 +45,7 @@ function generateBaseConfig({ entry, type, tmpdir }) {
 
     const [babelRule] = baseConfig.module.rules;
     babelRule.test = /\.jsx?$/;
-    babelRule.use.options = { presets: [babelPresetReact] };
+    babelRule.use.options.presets = [babelPresetReact];
   }
   return baseConfig;
 }

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -54,7 +54,7 @@ export default async function loadUserConfig(pathToConfigFile, env = process.env
   if (!config.targets || Object.keys(config.targets).length === 0) {
     throw new Error(
       'You need at least one target defined under `targets`. ' +
-        'See https://github.com/enduire/happo.io#targets for more info.',
+        'See https://github.com/happo/happo.io#targets for more info.',
     );
   }
   config.plugins.forEach(({ publicFolders }) => {

--- a/test/integrations/examples/Foo-react-happo.js
+++ b/test/integrations/examples/Foo-react-happo.js
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 
 import Button from './Button.ffs';
 
+const dynamicImportPromise = import('./dynamically-imported');
+
 export default () => {
   window.injectCSS('button { color: red }');
   return <Button />;
@@ -54,3 +56,21 @@ export const asyncExample = (render) => {
   component.setLabel('Ready');
   return new Promise((resolve) => setTimeout(resolve, 11));
 };
+
+class DynamicImportExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  async componentDidMount() {
+    const res = await dynamicImportPromise;
+    this.setState({ text: `${res.default} ${res.world}` }); // eslint-disable-line react/no-did-mount-set-state
+  }
+
+  render() {
+    return <div>{this.state.text}</div>;
+  }
+}
+
+export const dynamicImportExample = () => <DynamicImportExample />;

--- a/test/integrations/examples/dynamically-imported.js
+++ b/test/integrations/examples/dynamically-imported.js
@@ -1,0 +1,2 @@
+export default 'Hello';
+export const world = 'world';

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -79,6 +79,12 @@ it('produces the right html', async () => {
     {
       component: 'Foo-react',
       css: '',
+      html: '<div>Hello world</div>',
+      variant: 'dynamicImportExample',
+    },
+    {
+      component: 'Foo-react',
+      css: '',
       html: '<button>Click me</button>',
       variant: 'default',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,47 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.46"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz#e0d002100805daab1461c0fcb32a07e304f3a4f4"
   dependencies:
     "@babel/highlight" "7.0.0-beta.46"
+
+"@babel/generator@^7.0.0":
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.1.2.tgz#fde75c072575ce7abbd97322e8fef5bae67e4630"
+  dependencies:
+    "@babel/types" "^7.1.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+  dependencies:
+    "@babel/types" "^7.0.0"
 
 "@babel/highlight@7.0.0-beta.46":
   version "7.0.0-beta.46"
@@ -15,6 +51,48 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.1.2.tgz#85c5c47af6d244fab77bce6b9bd830e38c978409"
+
+"@babel/template@^7.1.0":
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.1.2"
+    "@babel/types" "^7.1.2"
+
+"@babel/traverse@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz#503ec6669387efd182c3888c4eec07bcc45d91b2"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
+"@babel/types@^7.0.0", "@babel/types@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.1.2.tgz#183e7952cf6691628afdc2e2b90d03240bac80c0"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
 
 "@webassemblyjs/ast@1.5.12":
   version "1.5.12"
@@ -494,6 +572,17 @@ babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
@@ -643,6 +732,13 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.1.0.tgz#ce874a6a1b97091ae0f56fedef0237c0951ee553"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    object.assign "^4.1.0"
+
 babel-plugin-istanbul@^4.1.5:
   version "4.1.6"
   resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -659,6 +755,10 @@ babel-plugin-jest-hoist@^22.4.3:
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -1988,7 +2088,7 @@ eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
-eslint-scope@^3.7.1:
+eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
@@ -2479,6 +2579,10 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
 globals@^11.0.1:
   version "11.5.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
+
+globals@^11.1.0:
+  version "11.8.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -3352,6 +3456,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.11.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -3427,6 +3535,10 @@ jsdom@^12.0.0:
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -3643,6 +3755,10 @@ lodash.sortby@^4.7.0:
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lodash@^4.17.10:
+  version "4.17.11"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 long@^3.2.0:
   version "3.2.0"
@@ -4084,6 +4200,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.11:
+  version "1.0.12"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
@@ -4093,6 +4213,15 @@ object-visit@^1.0.0:
   resolved "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -5026,7 +5155,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -5300,6 +5429,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 to-object-path@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
By default, [webpack will treat a dynamic import as a split point](https://webpack.js.org/api/module-methods/#import-),
meaning it will try to download a bundle as part of evaluating an
`import(somePath)` statement. This won't work for Happo -- since there's
no running server, people end up with something like this:

```
  Error: Could not load script: "http://localhost/92.happo-bundle-react-L3Jvb3Qvc3R1ZGlv.js"
      at onErrorWrapped (/root/studio/node_modules/jsdom/lib/jsdom/browser/resources/per-document-resource-loader.js:39:19)
      at Object.check (/root/studio/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:58:23)
      at request.then.catch.err (/root/studio/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:104:14)
```

To work around this, I'm using the [babel-plugin-dynamic-import-node](https://www.npmjs.com/package/babel-plugin-dynamic-import-node)
babel plugin. Thanks to @ljharb for making the suggestion and writing
the plugin. This plugin will transpile `import()` into a (deferred)
regular `require`, which is all we need to avoid the split point in
webpack.

While adding a test for this, I had to modify eslint a little, plus add
a babel plugin to make the dynamic imports recognized as valid syntax.

Fixes #31 