### PR TITLE
Allow custom render wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,10 +697,10 @@ module.exports = {
 
 ### `setupScript`
 
-A path to a file that will be executed before rendering your components. This
-is useful if you for instance want to inject global css styling (e.g. a css
-reset), custom fonts, polyfills etc. This script is executed in a DOM
-environment, so it's safe to inject things into the `<head>`.
+An absolute path to a file that will be executed before rendering your
+components. This is useful if you for instance want to inject global css
+styling (e.g. a css reset), custom fonts, polyfills etc. This script is
+executed in a DOM environment, so it's safe to inject things into the `<head>`.
 
 ```js
 const path = require('path');
@@ -708,6 +708,29 @@ const path = require('path');
 module.exports = {
   setupScript: path.resolve(__dirname, 'happoSetup.js'),
 }
+```
+
+### `renderWrapperModule`
+
+An absolute path to a file exporting a function where you can wrap rendering of
+Happo examples. This can be useful if you for instance have a theme provider or
+a store provider.
+
+```js
+// .happo.js
+const path = require('path');
+
+module.exports = {
+  renderWrapperModule: path.resolve(__dirname, 'happoWrapper.js'),
+}
+```
+
+```js
+// happoWrapper.js
+import React from 'react';
+import ThemeProvider from '../ThemeProvider';
+
+export default (component) => <ThemeProvider>{component}</ThemeProvider>;
 ```
 
 ### `rootElementSelector`

--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -9,6 +9,7 @@ export const type = 'react';
 export const plugins = [];
 export const publicFolders = [];
 export const tmpdir = os.tmpdir();
+export const renderWrapperModule = require.resolve('./renderWrapper');
 export function customizeWebpackConfig(config) {
   // provide a default no-op for this config option so that we can assume it's
   // always there.

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -107,6 +107,7 @@ export default async function domRunner(
     targets,
     publicFolders,
     rootElementSelector,
+    renderWrapperModule,
     type,
     plugins,
     tmpdir,
@@ -137,6 +138,7 @@ export default async function domRunner(
       plugins,
       tmpdir,
       rootElementSelector,
+      renderWrapperModule,
     });
     entryFile = entryPointResult.entryFile;
     logger.success(`${entryPointResult.numberOfFilesProcessed} found`);

--- a/src/renderWrapper.js
+++ b/src/renderWrapper.js
@@ -1,0 +1,11 @@
+// This is the default, no-op, render wrapper. If you're looking to provide your
+// own, it might look something like this:
+// ```
+// /* In React */
+// export default (component) => <Wrapper>{component}</Wrapper>
+// ```
+// ```
+// /* In a plain-js project */
+// export default (html) => '<div>' + html + '</div>';
+// ```
+export default (result) => result;

--- a/test/integrations/examples/Foo-react-happo.js
+++ b/test/integrations/examples/Foo-react-happo.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import Button from './Button.ffs';
+import ThemeContext from '../theme';
 
 const dynamicImportPromise = import('./dynamically-imported');
 
@@ -33,14 +34,20 @@ class AsyncComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+    this.setLabel = this.setLabel.bind(this);
   }
 
   componentDidMount() {
     setTimeout(() => this.setState({ ready: true }), 10);
+    window.addEventListener('set-label', this.setLabel);
   }
 
-  setLabel(label) {
-    this.setState({ label });
+  componentWillUnmount() {
+    window.removeEventListener('set-label', this.setLabel);
+  }
+
+  setLabel(e) {
+    this.setState({ label: e.detail });
   }
 
   render() {
@@ -52,8 +59,8 @@ class AsyncComponent extends React.Component {
 }
 
 export const asyncExample = (render) => {
-  const component = render(<AsyncComponent />);
-  component.setLabel('Ready');
+  render(<AsyncComponent />);
+  window.dispatchEvent(new CustomEvent('set-label', { detail: 'Ready' })); // eslint-disable-line no-undef
   return new Promise((resolve) => setTimeout(resolve, 11));
 };
 
@@ -74,3 +81,9 @@ class DynamicImportExample extends React.Component {
 }
 
 export const dynamicImportExample = () => <DynamicImportExample />;
+
+export const themedExample = () => (
+  <ThemeContext.Consumer>
+    {theme => <button>I am {theme}</button>}
+  </ThemeContext.Consumer>
+);

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -18,6 +18,7 @@ beforeEach(() => {
     targets: { chrome: new MockTarget() },
     include: 'test/integrations/examples/*-react-happo.js*',
     setupScript: path.resolve(__dirname, 'reactSetup.js'),
+    renderWrapperModule: path.resolve(__dirname, 'renderWrapper.js'),
     plugins: [
       {
         pathToExamplesFile: path.resolve(__dirname, 'plugin-examples.js'),
@@ -81,6 +82,12 @@ it('produces the right html', async () => {
       css: '',
       html: '<div>Hello world</div>',
       variant: 'dynamicImportExample',
+    },
+    {
+      component: 'Foo-react',
+      css: '',
+      html: '<button>I am dark</button>',
+      variant: 'themedExample',
     },
     {
       component: 'Foo-react',

--- a/test/integrations/renderWrapper.js
+++ b/test/integrations/renderWrapper.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import ThemeContext from './theme';
+
+export default component => (
+  <ThemeContext.Provider value="dark">
+    {component}
+  </ThemeContext.Provider>
+);

--- a/test/integrations/theme.js
+++ b/test/integrations/theme.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext('light');


### PR DESCRIPTION
A lot of projects using Happo end up relying on wrapper components
automatically injecting things like theme properties, store bindings etc
through React contexts. To avoid having to specify these wrappers every
single time, I'm adding a `renderWrapperModule` config option. With this
option, they can implement a custom wrapping function for all Happo
examples, something like

```js
// .happo.js
renderWrapperModule: path.resolve(__dirname, 'happo-wrapper.js');
```

```js
// happo-wrapper.js

export default (component) => (
  <ThemeProvider>{component}</ThemeProvider>
);
```

Fixes #25