### PR TITLE
Fix missing error messages in typescript projects

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -13,9 +13,12 @@ const green = withColorSupport((str) => `\x1b[32m${str}\x1b[0m`);
 const underline = withColorSupport((str) => `\x1b[36m\x1b[4m${str}\x1b[0m`);
 
 export default class Logger {
-  constructor() {
-    this.print = (str) => process.stdout.write(str);
-    this.stderrPrint = (str) => process.stderr.write(str);
+  constructor({
+    stderrPrint = (str) => process.stderr.write(str),
+    print = (str) => process.stdout.write(str),
+  } = {}) {
+    this.print = print;
+    this.stderrPrint = stderrPrint;
   }
 
   mute() {
@@ -53,7 +56,7 @@ export default class Logger {
   }
 
   error(e) {
-    this.stderrPrint(red(e.stack));
+    this.stderrPrint(red(e.stack || e.message));
     this.stderrPrint('\n');
   }
 }

--- a/test/Logger-test.js
+++ b/test/Logger-test.js
@@ -1,0 +1,43 @@
+import Logger from '../src/Logger';
+
+let subject;
+let stderrPrint;
+let print;
+
+beforeEach(() => {
+  stderrPrint = jest.fn();
+  print = jest.fn();
+  subject = () => new Logger({ print, stderrPrint });
+});
+
+it('works without injected printers', () => {
+  // This test is here just to make sure that the dependency injection of the
+  // `print` and `stderrPrint` functions isn't causing any issues
+  const error = new Error('Ignore this log');
+  delete error.stack;
+  new Logger().error(error);
+  new Logger().info('Ignore this log');
+});
+
+it('does not print to stdout on errors', () => {
+  subject().error(new Error('foo'));
+  expect(print.mock.calls.length).toBe(0);
+});
+
+it('logs errors with stacks', () => {
+  const error = new Error('damn');
+  error.stack = 'foobar';
+  subject().error(error);
+  // We have to use `toMatch` here because the string is wrapped with color
+  // instruction characters
+  expect(stderrPrint.mock.calls[0][0]).toMatch(/foobar/);
+});
+
+it('logs errors without stacks', () => {
+  const error = new Error('damn');
+  delete error.stack;
+  subject().error(error);
+  // We have to use `toMatch` here because the string is wrapped with color
+  // instruction characters
+  expect(stderrPrint.mock.calls[0][0]).toMatch(/damn/);
+});


### PR DESCRIPTION
While trying out the new `renderWrapperModule` config option in a
typescript project, @benbayard got a confusing error (not exactly this
one, but similar):

⨠ yarn happo run
yarn run v1.6.0
$ happo run
No [sha] provided. A temporary one will be used in place: "dev-13b823211c163ed66330".
Reading files... ✓ 1 found
Creating bundle... ts-loader: Using typescript@3.1.2 and /Users/henrictrotzig/happo-demo-t
ypescript/tsconfig.json
undefined
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
→ exit status: 1

What's interesting here is the line that logs "undefined". It turns out
that it's coming from src/Logger.js, and it's because the error in
typescript doesn't have a `stack` property. It does have a good error
message however, so we can just fall back to the message in lieu of the
stack.

Fixes #34