### PR TITLE
Include typescript files when searching by extension

### DIFF
--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -1,7 +1,7 @@
 import os from 'os';
 
 export const endpoint = 'https://happo.io';
-export const include = '**/@(*-happo|happo).@(js|jsx)';
+export const include = '**/@(*-happo|happo).@(js|jsx|ts|tsx)';
 export const stylesheets = [];
 export const targets = {};
 export const configFile = './.happo.js';

--- a/src/createWebpackBundle.js
+++ b/src/createWebpackBundle.js
@@ -14,7 +14,7 @@ function generateBaseConfig({ entry, type, tmpdir }) {
       path: tmpdir,
     },
     resolve: {
-      extensions: ['*', '.js', '.jsx', '.json'],
+      extensions: ['*', '.js', '.jsx', '.json', '.ts', '.tsx'],
     },
     module: {
       rules: [


### PR DESCRIPTION
This will make it easier to use happo in typescript projects, since you
no longer have to override things, e.g.

  customizeWebpackConfig: config => {
      config.resolve = Object.assign({}, config.resolve, {
        extensions: ['.tsx', '.ts', '.js'],
      }); // add in the existing config.resolve that happo needs
      return config;
  }

  include: '**/@(*-happo|happo).@(ts|tsx)',

While this is very specific to typescript, it shouldn't hurt regular
projects.