### PR TITLE
Allow plugins to inject css outside of rendering examples

### DIFF
--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -50,6 +50,7 @@ async function generateScreenshots(
   logger,
 ) {
   const cssBlocks = await Promise.all(stylesheets.map(loadCSSFile));
+  plugins.forEach(({ css }) => cssBlocks.push(css || ''));
 
   const targetNames = Object.keys(targets);
   const tl = targetNames.length;

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -22,6 +22,7 @@ beforeEach(() => {
     plugins: [
       {
         pathToExamplesFile: path.resolve(__dirname, 'plugin-examples.js'),
+        css: '.plugin-injected { color: red }',
       },
       {
         customizeWebpackConfig: (cfg) => {
@@ -114,7 +115,7 @@ it('produces the right css', async () => {
   await subject();
   expect(config.targets.chrome.globalCSS).toEqual(
     `
-   button { text-align: center }\nbutton { color: red }
+   .plugin-injected { color: red }button { text-align: center }\nbutton { color: red }
     `.trim(),
   );
 });


### PR DESCRIPTION
I'm working on the happo-plugin-scrape plugin where I'm running into
performance issues related to css handling. The slow part is injecting a
large block of css collected in the scrape phase to the JSDOM instance.
Instead of doing that, we can allow the plugin to directly inject css,
avoiding the need to pass this css through the JSDOM instance.