### PR TITLE
Allow for more flexible babel-core peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack": "^4.14.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0 || ^7.0.0",
+    "babel-core": "^6.0.0 || ^7.0.0-0",
     "babel-loader": "^7.0.0 || ^8.0.0",
     "webpack": "^3.5.5 || ^4.0.0"
   }


### PR DESCRIPTION
Hi :wave:,

I am working on upgrading a project to babel 7 and noticed a console warning from happo after an npm install.

```sh
npm WARN happo.io@3.3.0 requires a peer of babel-core@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.
```

I do actually have babel-core installed, but it is `7.0.0-bridge.0` as necessitated by jest, as described here --> https://jestjs.io/docs/en/getting-started.html#using-babel.

This PR simply loosens up the versioning a tad to allow for the `-bridge.0` portion.



