### PR TITLE
Add project param

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,12 @@ folder. You can override the path to this file through the `--config` CLI
 option. This file isn't subject to babel transpilation, so it's best to stay
 with good old CommonJS syntax unless you're on the very latest Node version.
 
+### `project`
+
+If you have multiple projects configured for your happo.io account, you can
+specify the name of the project you want to associate with. If you leave this
+empty, the default project will be used.
+
 ### `include`
 
 Controls what files happo will grab examples from. The default is

--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -3,7 +3,7 @@ import makeRequest from '../makeRequest';
 export default function compareReports(
   sha1,
   sha2,
-  { apiKey, apiSecret, endpoint },
+  { apiKey, apiSecret, endpoint, project },
   { link, message, author },
 ) {
   return makeRequest(
@@ -15,6 +15,7 @@ export default function compareReports(
         link,
         message,
         author,
+        project,
       },
     },
     { apiKey, apiSecret },

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -9,7 +9,7 @@ function indent(str) {
 }
 
 export default async function devCommand(config, { only }) {
-  const { apiKey, apiSecret, endpoint } = config;
+  const { apiKey, apiSecret, endpoint, project } = config;
   let baselineSha;
   const logger = new Logger();
   domRunner(config, {
@@ -23,6 +23,7 @@ export default async function devCommand(config, { only }) {
         endpoint,
         apiKey,
         apiSecret,
+        project,
       });
       logger.success();
       logger.info(`View results at ${url}`);
@@ -32,7 +33,7 @@ export default async function devCommand(config, { only }) {
         const result = await compareReportsCommand(
           baselineSha,
           sha,
-          { apiKey, apiSecret, endpoint },
+          { apiKey, apiSecret, endpoint, project },
           {},
         );
         logger.success();

--- a/src/commands/hasReport.js
+++ b/src/commands/hasReport.js
@@ -1,12 +1,13 @@
 import fetchReport from '../fetchReport';
 
-export default async function hasReport(sha, { apiKey, apiSecret, endpoint }) {
+export default async function hasReport(sha, { apiKey, apiSecret, endpoint, project }) {
   try {
     await fetchReport({
       sha,
       apiKey,
       apiSecret,
       endpoint,
+      project,
     });
     return true;
   } catch (e) {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,7 +4,7 @@ import uploadReport from '../uploadReport';
 
 export default async function runCommand(sha, config, { only, link, message }) {
   const logger = new Logger();
-  const { apiKey, apiSecret, endpoint } = config;
+  const { apiKey, apiSecret, endpoint, project } = config;
   const snaps = await domRunner(config, { only });
   logger.start(`Uploading report for ${sha}...`);
   const { url } = await uploadReport({
@@ -15,6 +15,7 @@ export default async function runCommand(sha, config, { only, link, message }) {
     apiSecret,
     link,
     message,
+    project,
   });
   logger.success();
   logger.info(`View results at ${url}`);

--- a/src/fetchReport.js
+++ b/src/fetchReport.js
@@ -1,9 +1,9 @@
 import makeRequest from './makeRequest';
 
-export default function fetchReport({ sha, endpoint, apiKey, apiSecret }) {
+export default function fetchReport({ sha, endpoint, apiKey, apiSecret, project }) {
   return makeRequest(
     {
-      url: `${endpoint}/api/reports/${sha}`,
+      url: `${endpoint}/api/reports/${sha}${project ? `?project=${project}` : ''}`,
       method: 'GET',
       json: true,
     },

--- a/src/uploadReport.js
+++ b/src/uploadReport.js
@@ -1,6 +1,15 @@
 import makeRequest from './makeRequest';
 
-export default function uploadReport({ snaps, sha, endpoint, apiKey, apiSecret, link, message }) {
+export default function uploadReport({
+  snaps,
+  sha,
+  endpoint,
+  apiKey,
+  apiSecret,
+  link,
+  message,
+  project,
+}) {
   return makeRequest(
     {
       url: `${endpoint}/api/reports/${sha}`,
@@ -10,6 +19,7 @@ export default function uploadReport({ snaps, sha, endpoint, apiKey, apiSecret, 
         snaps,
         link,
         message,
+        project,
       },
     },
     { apiKey, apiSecret },

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -15,6 +15,7 @@ beforeEach(() => {
   makeRequest.mockImplementation(() => Promise.resolve({}));
   sha = 'foobar';
   config = Object.assign({}, defaultConfig, {
+    project: 'the project',
     targets: { chrome: new MockTarget() },
     include: 'test/integrations/examples/*-react-happo.js*',
     setupScript: path.resolve(__dirname, 'reactSetup.js'),
@@ -43,6 +44,11 @@ beforeEach(() => {
     ],
   });
   subject = () => runCommand(sha, config, {});
+});
+
+it('sends the project name in the request', async () => {
+  await subject();
+  expect(makeRequest.mock.calls[0][0].body.project).toEqual('the project');
 });
 
 it('produces the right html', async () => {


### PR DESCRIPTION
Now that happo.io accepts a `project` param for certain API endpoints,
we can start making use of it.

A happo.io account can have multiple projects. There's at least one,
default project. If you don't specify the project in config, we'll use
the default project as configured at happo.io. If the project is
configured, we'll associate reports/comparisons with that project. If
the project specified in .happo.js config does not exist, it will be
created the first time you use it.