### PR TITLE
Make things work without a .happo.js config file

### DIFF
--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -1,9 +1,17 @@
 import os from 'os';
 
+import RemoteBrowserTarget from './RemoteBrowserTarget';
+
+export const apiKey = process.env.HAPPO_API_KEY;
+export const apiSecret = process.env.HAPPO_API_SECRET;
 export const endpoint = 'https://happo.io';
 export const include = '**/@(*-happo|happo).@(js|jsx|ts|tsx)';
 export const stylesheets = [];
-export const targets = {};
+export const targets = {
+  chrome: new RemoteBrowserTarget('chrome', {
+    viewport: '1024x768',
+  }),
+};
 export const configFile = './.happo.js';
 export const type = 'react';
 export const plugins = [];

--- a/test/jestSetup.js
+++ b/test/jestSetup.js
@@ -1,1 +1,3 @@
 jest.setTimeout(10000);
+delete process.env.HAPPO_API_KEY;
+delete process.env.HAPPO_API_SECRET;


### PR DESCRIPTION
This will make it easier to use Happo out of the box. Instead of relying
on the user to fill in targets and apiKey/apiSecret, we can default the
values.

Having the api tokens defined as environment variables is a good thing
anyway, so this should simplify some documentation going forward and
make things a little more secure.