### PR TITLE
Prevent failing run with webpack 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ addons:
 node_js:
   - "6"
   - "8"
-script: yarn lint && yarn test
+script: yarn lint && yarn test && yarn add --dev webpack@3 && yarn test

--- a/src/createWebpackBundle.js
+++ b/src/createWebpackBundle.js
@@ -11,7 +11,6 @@ function generateBaseConfig({ entry, type, tmpdir }) {
   const outFile = `happo-bundle-${type}-${createHash(process.cwd()).slice(0, 5)}.js`;
   const babelLoader = require.resolve('babel-loader');
   const baseConfig = {
-    mode: 'development',
     devtool: 'nosources-source-map',
     entry,
     output: {
@@ -38,6 +37,14 @@ function generateBaseConfig({ entry, type, tmpdir }) {
     },
     plugins: [],
   };
+  if (/^[4567]\./.test(webpack.version)) {
+    if (VERBOSE === 'true') {
+      console.log('Detected webpack version >=4. Using `mode: "development"`.');
+    }
+    baseConfig.mode = 'development';
+  } else if (VERBOSE === 'true') {
+    console.log('Detected webpack version <4. If you upgrade to >=4, stack traces from Happo will be a little better.');
+  }
   if (type === 'react') {
     let babelPresetReact;
     try {


### PR DESCRIPTION
The `mode` option wasn't added until version 4. Having it in the config
makes happo runs fail on webpack <4. We can be a little bit smarter
about adding it.

Added webpack@3 to the Travis build so that we don't end up regressing
here.