### PR TITLE
Add support for static builds from plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.6.2",
+  "version": "3.7.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -38,7 +38,7 @@ export default class RemoteBrowserTarget {
     this.viewport = viewport;
   }
 
-  async execute({ globalCSS, snapPayloads, apiKey, apiSecret, endpoint }) {
+  async execute({ globalCSS, staticPackage, snapPayloads, apiKey, apiSecret, endpoint }) {
     const { requestId } = await makeRequest(
       {
         url: `${endpoint}/api/snap-requests`,
@@ -50,6 +50,7 @@ export default class RemoteBrowserTarget {
             viewport: this.viewport,
             globalCSS,
             snapPayloads,
+            staticPackage,
           },
         },
       },

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,11 +1,20 @@
 import Logger from '../Logger';
 import domRunner from '../domRunner';
+import remoteRunner from '../remoteRunner';
 import uploadReport from '../uploadReport';
 
 export default async function runCommand(sha, config, { only, link, message }) {
   const logger = new Logger();
-  const { apiKey, apiSecret, endpoint, project } = config;
-  const snaps = await domRunner(config, { only });
+  const { apiKey, apiSecret, endpoint, project, plugins } = config;
+
+  const staticPlugin = plugins.find((plugin) => typeof plugin.generateStaticPackage === 'function');
+  let snaps;
+  if (staticPlugin) {
+    snaps = await remoteRunner(config, staticPlugin);
+  } else {
+    snaps = await domRunner(config, { only });
+  }
+
   logger.start(`Uploading report for ${sha}...`);
   const { url } = await uploadReport({
     snaps,

--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -1,0 +1,34 @@
+import Logger from './Logger';
+import constructReport from './constructReport';
+
+export default async function remoteRunner(
+  { apiKey, apiSecret, endpoint, targets },
+  { generateStaticPackage },
+) {
+  const logger = new Logger();
+  try {
+    logger.info('Generating static package...');
+    const staticPackage = await generateStaticPackage();
+    const targetNames = Object.keys(targets);
+    const tl = targetNames.length;
+    logger.info(`Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
+    const results = await Promise.all(
+      targetNames.map(async (name) => {
+        const result = await targets[name].execute({
+          staticPackage,
+          apiKey,
+          apiSecret,
+          endpoint,
+        });
+        logger.start(`  - ${name}`);
+        logger.success();
+        return { name, result };
+      }),
+    );
+    logger.success();
+    return constructReport(results);
+  } catch (e) {
+    logger.fail();
+    throw e;
+  }
+}

--- a/test/integrations/MockTarget.js
+++ b/test/integrations/MockTarget.js
@@ -3,9 +3,10 @@ export default class MockTarget {
     this.viewport = '800x600';
   }
 
-  execute({ globalCSS, snapPayloads }) {
+  execute({ globalCSS, snapPayloads, staticPackage }) {
     this.globalCSS = globalCSS;
     this.snapPayloads = snapPayloads;
+    this.staticPackage = staticPackage;
     return [];
   }
 }

--- a/test/integrations/static-test.js
+++ b/test/integrations/static-test.js
@@ -1,0 +1,35 @@
+import MockTarget from './MockTarget';
+import * as defaultConfig from '../../src/DEFAULTS';
+import makeRequest from '../../src/makeRequest';
+import runCommand from '../../src/commands/run';
+
+jest.mock('../../src/makeRequest');
+
+let subject;
+let config;
+let sha;
+
+beforeEach(() => {
+  makeRequest.mockImplementation(() => Promise.resolve({}));
+  sha = 'foobar';
+  config = Object.assign({}, defaultConfig, {
+    project: 'the project',
+    targets: { chrome: new MockTarget() },
+    plugins: [
+      {
+        generateStaticPackage: () => Promise.resolve('a base64-encoded string'),
+      },
+    ],
+  });
+  subject = () => runCommand(sha, config, {});
+});
+
+it('sends the project name in the request', async () => {
+  await subject();
+  expect(makeRequest.mock.calls[0][0].body.project).toEqual('the project');
+});
+
+it('produces the static package', async () => {
+  await subject();
+  expect(config.targets.chrome.staticPackage).toEqual('a base64-encoded string');
+});


### PR DESCRIPTION
I'm working on improvements to the happo-plugin-storybook plugin. As
part of that, I'm making plugins able to bypass local DOM rendering and
instead send a full static build to happo.io for remote execution.