### PR TITLE
Create consistent zip packages

### DIFF
--- a/src/prepareAssetsPackage.js
+++ b/src/prepareAssetsPackage.js
@@ -6,6 +6,10 @@ import Archiver from 'archiver';
 
 import findCSSAssetPaths from './findCSSAssetPaths';
 
+// We're setting the creation date to the same for all files so that the zip
+// packages created for the same content ends up having the same fingerprint.
+const FILE_CREATION_DATE = new Date('Fri Feb 08 2019 13:31:55 GMT+0100 (CET)');
+
 function makePackage({ paths, publicFolders }) {
   return new Promise((resolve, reject) => {
     const archive = new Archiver('zip');
@@ -27,7 +31,10 @@ function makePackage({ paths, publicFolders }) {
       for (const folder of publicFolders) {
         const fullPath = path.join(folder, assetPath);
         if (fs.existsSync(fullPath)) {
-          archive.append(fs.createReadStream(fullPath), { name: assetPath });
+          archive.append(fs.createReadStream(fullPath), {
+            name: assetPath,
+            date: FILE_CREATION_DATE,
+          });
           return;
         }
       }
@@ -38,11 +45,7 @@ function makePackage({ paths, publicFolders }) {
   });
 }
 
-export default function prepareAssetsPackage({
-  globalCSS,
-  snapPayloads,
-  publicFolders,
-}) {
+export default function prepareAssetsPackage({ globalCSS, snapPayloads, publicFolders }) {
   const paths = new Set();
   globalCSS.forEach(({ css }) => {
     findCSSAssetPaths(css).forEach((cssPath) => {

--- a/test/prepareAssetsPackage-test.js
+++ b/test/prepareAssetsPackage-test.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 
 import prepareAssetsPackage from '../src/prepareAssetsPackage';
@@ -11,16 +12,26 @@ beforeEach(() => {
   globalCSS = [{ css: '.foo { background: url(/inlineResources/1x1.png) }' }];
   snapPayloads = [{ assetPaths: ['inlineResources/1x1.png'] }];
   publicFolders = [__dirname];
-  subject = () => prepareAssetsPackage({
-    globalCSS,
-    snapPayloads,
-    publicFolders,
-  });
+  subject = () =>
+    prepareAssetsPackage({
+      globalCSS,
+      snapPayloads,
+      publicFolders,
+    });
 });
 
 it('creates a package when there are assets', async () => {
   const result = await subject();
   expect(result).not.toBe(undefined);
+});
+
+it('creates consistent results', async () => {
+  const first = await subject();
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  const filename = path.resolve(__dirname, 'inlineResources/1x1.png');
+  fs.utimesSync(filename, new Date(), new Date());
+  const second = await subject();
+  expect(first).toEqual(second);
 });
 
 it('does not fail when files are missing', async () => {


### PR DESCRIPTION
I noticed that payload caching isn't working well with the latest
version of the happo.io client. This is because `archiver` is making
different zip packages every time. By locking the creation date to a
specific time we can have consistent packages created.