### PR TITLE
Retry requests

### DIFF
--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -10,7 +10,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
       method: 'GET',
       json: true,
     },
-    { apiKey, apiSecret },
+    { apiKey, apiSecret, maxTries: 3 },
   );
   if (status === 'done') {
     return result;
@@ -69,7 +69,7 @@ export default class RemoteBrowserTarget {
             },
           },
         },
-        { apiKey, apiSecret },
+        { apiKey, apiSecret, maxTries: 2 },
       );
     if (staticPackage) {
       const { requestId: staticReqId } = await boundMakeRequest();

--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -18,6 +18,6 @@ export default function compareReports(
         project,
       },
     },
-    { apiKey, apiSecret },
+    { apiKey, apiSecret, maxTries: 2 },
   );
 }

--- a/src/makeRequest.js
+++ b/src/makeRequest.js
@@ -1,7 +1,11 @@
-import request from 'request-promise-native';
 import jwt from 'jsonwebtoken';
+import request from 'request-promise-native';
 
-export default async function makeRequest(requestAttributes, { apiKey, apiSecret }, tryNumber = 1) {
+export default async function makeRequest(
+  requestAttributes,
+  { apiKey, apiSecret, maxTries = 0 },
+  tryNumber = 1,
+) {
   const signed = jwt.sign({ key: apiKey }, apiSecret, { header: { kid: apiKey } });
   try {
     const result = await request(
@@ -17,11 +21,19 @@ export default async function makeRequest(requestAttributes, { apiKey, apiSecret
     );
     return result;
   } catch (e) {
-    if (tryNumber >= 3) {
+    if (tryNumber >= maxTries) {
       throw e;
     }
     console.warn(`Failed to make request to ${requestAttributes.url}. Retrying after 2s...`);
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    return makeRequest(requestAttributes, { apiKey, apiSecret }, tryNumber + 1);
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    return makeRequest(
+      requestAttributes,
+      {
+        apiKey,
+        apiSecret,
+        maxTries,
+      },
+      tryNumber + 1,
+    );
   }
 }

--- a/src/makeRequest.js
+++ b/src/makeRequest.js
@@ -1,17 +1,27 @@
 import request from 'request-promise-native';
 import jwt from 'jsonwebtoken';
 
-export default function makeRequest(requestAttributes, { apiKey, apiSecret }) {
+export default async function makeRequest(requestAttributes, { apiKey, apiSecret }, tryNumber = 1) {
   const signed = jwt.sign({ key: apiKey }, apiSecret, { header: { kid: apiKey } });
-  return request(
-    Object.assign(
-      {
-        gzip: true,
-        auth: {
-          bearer: signed,
+  try {
+    const result = await request(
+      Object.assign(
+        {
+          gzip: true,
+          auth: {
+            bearer: signed,
+          },
         },
-      },
-      requestAttributes,
-    ),
-  );
+        requestAttributes,
+      ),
+    );
+    return result;
+  } catch (e) {
+    if (tryNumber >= 3) {
+      throw e;
+    }
+    console.warn(`Failed to make request to ${requestAttributes.url}. Retrying after 2s...`);
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    return makeRequest(requestAttributes, { apiKey, apiSecret }, tryNumber + 1);
+  }
 }

--- a/src/uploadReport.js
+++ b/src/uploadReport.js
@@ -22,6 +22,6 @@ export default function uploadReport({
         project,
       },
     },
-    { apiKey, apiSecret },
+    { apiKey, apiSecret, maxTries: 2 },
   );
 }

--- a/test/makeRequest-test.js
+++ b/test/makeRequest-test.js
@@ -1,0 +1,59 @@
+import request from 'request-promise-native';
+
+import makeRequest from '../src/makeRequest';
+
+jest.mock('request-promise-native');
+
+let subject;
+let props;
+let secrets;
+
+beforeEach(() => {
+  request.mockImplementation(async () => 'Hello world!');
+  props = {
+    url: 'https://happo.io',
+    method: 'GET',
+  };
+  secrets = {
+    apiKey: 'foo',
+    apiSecret: 'bar',
+  };
+  subject = () => makeRequest(props, secrets);
+});
+
+it('returns the response', async () => {
+  const response = await subject();
+  expect(response).toEqual('Hello world!');
+});
+
+describe('when the request fails twice', () => {
+  beforeEach(() => {
+    props.url = 'http://sometimes-throws';
+    let tries = 0;
+    request.mockImplementation(async () => {
+      tries += 1;
+      if (tries < 3) {
+        throw new Error('Nope');
+      }
+      return 'Foo bar';
+    });
+  });
+
+  it('retries and succeeds', async () => {
+    const response = await subject();
+    expect(response).toEqual('Foo bar');
+  });
+});
+
+describe('when the request fails repeatedly', () => {
+  beforeEach(() => {
+    props.url = 'http://always-throws';
+    request.mockImplementation(async () => {
+      throw new Error('Nope');
+    });
+  });
+
+  it('gives up retrying', async () => {
+    await expect(subject()).rejects.toThrow(/Nope/);
+  });
+});


### PR DESCRIPTION
After getting feedback that happo runs are flaky in CI, I decided to add
some retry-logic to the requests made from the client. The new logic
will make requests retry up to three times with a two second delay
before giving up.