### PR TITLE
Pass along snapRequestId with snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.10.2",
+  "version": "3.11.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.11.0-rc.1",
+  "version": "3.11.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -13,7 +13,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
     { apiKey, apiSecret, maxTries: 3 },
   );
   if (status === 'done') {
-    return result;
+    return result.map((i) => Object.assign({}, i, { snapRequestId: requestId }));
   }
   await new Promise((r) => setTimeout(r, POLL_INTERVAL));
   return waitFor({ requestId, endpoint, apiKey, apiSecret });
@@ -90,6 +90,7 @@ export default class RemoteBrowserTarget {
     (await Promise.all(promises)).forEach((list) => {
       result.push(...list);
     });
+
     return result;
   }
 }

--- a/src/constructReport.js
+++ b/src/constructReport.js
@@ -1,7 +1,7 @@
 export default async function constructReport(results) {
   const report = [];
   results.forEach(({ name: target, result }) => {
-    result.forEach(({ component, variant, url, width, height }) => {
+    result.forEach(({ component, variant, url, width, height, snapRequestId }) => {
       report.push({
         component,
         variant,
@@ -9,6 +9,7 @@ export default async function constructReport(results) {
         width,
         height,
         target,
+        snapRequestId,
       });
     });
   });

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -63,7 +63,10 @@ describe('#execute', () => {
         endpoint: 'http://localhost',
       });
 
-      expect(result).toEqual([{ component: 'foobar' }, { component: 'foobar' }]);
+      expect(result).toEqual([
+        { component: 'foobar', snapRequestId: 44 },
+        { component: 'foobar', snapRequestId: 44 },
+      ]);
 
       // two POSTs and two GETs
       expect(makeRequest.mock.calls.length).toBe(4);
@@ -91,7 +94,7 @@ describe('#execute', () => {
         endpoint: 'http://localhost',
       });
 
-      expect(result).toEqual([{ component: 'foobar' }]);
+      expect(result).toEqual([{ component: 'foobar', snapRequestId: 44 }]);
 
       // one POST and one GET
       expect(makeRequest.mock.calls.length).toBe(2);
@@ -114,7 +117,7 @@ describe('#execute', () => {
           staticPackage: 'foobar',
         });
 
-        expect(result).toEqual([{ component: 'foobar' }]);
+        expect(result).toEqual([{ component: 'foobar', snapRequestId: 44 }]);
 
         // one POST and one GET
         expect(makeRequest.mock.calls.length).toBe(2);


### PR DESCRIPTION
This will allow the happo.io server to better associate sources with a
snapshot.