### PR TITLE
Add tests to verify chunks for large test suites

### DIFF
--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -76,7 +76,7 @@ export default class RemoteBrowserTarget {
       return waitFor({ requestId: staticReqId, endpoint, apiKey, apiSecret });
     }
     const promises = [];
-    const snapsPerChunk = snapPayloads.length / this.chunks;
+    const snapsPerChunk = Math.ceil(snapPayloads.length / this.chunks);
     for (let i = 0; i < this.chunks; i += 1) {
       const slice = snapPayloads.slice(i * snapsPerChunk, (i * snapsPerChunk) + snapsPerChunk);
       // We allow one `await` inside the loop here to avoid POSTing all payloads

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -126,4 +126,48 @@ describe('#execute', () => {
       });
     });
   });
+
+  [2049, 7296, 7297].forEach((count) => {
+    describe(`with ${count} snapshots`, () => {
+      let seenSnapshots;
+
+      beforeEach(() => {
+        seenSnapshots = new Set();
+        chunks = 16;
+
+        makeRequest.mockImplementation(({ body }) => {
+          if (body) {
+            const snaps = body.payload.snapPayloads;
+            snaps.forEach(({ html }) => {
+              seenSnapshots.add(html);
+            });
+          }
+          return Promise.resolve({
+            requestId: 44,
+            status: 'done',
+            result: [],
+          });
+        });
+      });
+
+      it('processes the right requests', async () => {
+        const target = subject();
+        const snaps = Array(count)
+          .fill()
+          .map((_, i) => ({
+            html: `snap-${i}`,
+          }));
+        await target.execute({
+          globalCSS: '* { color: red }',
+          snapPayloads: snaps,
+          apiKey: 'foobar',
+          apiSecret: 'p@assword',
+          endpoint: 'http://localhost',
+        });
+
+        expect(seenSnapshots.size).toEqual(count);
+        expect(makeRequest.mock.calls.length).toBe(32);
+      });
+    });
+  });
 });

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -71,11 +71,11 @@ describe('#execute', () => {
       // two POSTs and two GETs
       expect(makeRequest.mock.calls.length).toBe(4);
 
-      expect(makeRequest.mock.calls[0][0].body.payload.snapPayloads).toEqual([{ html: '<div/>' }]);
-      expect(makeRequest.mock.calls[2][0].body.payload.snapPayloads).toEqual([
+      expect(makeRequest.mock.calls[0][0].body.payload.snapPayloads).toEqual([
+        { html: '<div/>' },
         { html: '<button/>' },
-        { html: '<li/>' },
       ]);
+      expect(makeRequest.mock.calls[2][0].body.payload.snapPayloads).toEqual([{ html: '<li/>' }]);
     });
   });
 


### PR DESCRIPTION
I was suspecting a bug, off-by-one in the chunking mechanism in
RemoteBrowserTarget. But it doesn't look like I can provoke it.