### PR TITLE
Add support for chunks when using staticPackage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.11.1",
+  "version": "3.12.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -77,6 +77,37 @@ describe('#execute', () => {
       ]);
       expect(makeRequest.mock.calls[2][0].body.payload.snapPayloads).toEqual([{ html: '<li/>' }]);
     });
+
+    describe('with a staticPackage', () => {
+      it('sends the right requests', async () => {
+        const target = subject();
+        const result = await target.execute({
+          globalCSS: '* { color: red }',
+          apiKey: 'foobar',
+          apiSecret: 'p@assword',
+          endpoint: 'http://localhost',
+          staticPackage: 'foobar',
+        });
+
+        expect(result).toEqual([
+          { component: 'foobar', snapRequestId: 44 },
+          { component: 'foobar', snapRequestId: 44 },
+        ]);
+
+        // two POSTs and two GETs
+        expect(makeRequest.mock.calls.length).toBe(4);
+
+        expect(makeRequest.mock.calls[0][0].body.payload.staticPackage).toEqual('foobar');
+        expect(makeRequest.mock.calls[0][0].body.payload.chunk).toEqual({
+          index: 0,
+          total: 2,
+        });
+        expect(makeRequest.mock.calls[2][0].body.payload.chunk).toEqual({
+          index: 1,
+          total: 2,
+        });
+      });
+    });
   });
 
   describe('when chunks is equal to one', () => {


### PR DESCRIPTION
This will make it possible to split up happo runs involving the
happo-plugin-storybook plugin into multiple parallel ones.

The happo workers have already been updated to support the new chunks feature.