### PR TITLE
Don't silently fail when example has no render method

### DIFF
--- a/src/browser/getRenderFunc.js
+++ b/src/browser/getRenderFunc.js
@@ -1,0 +1,6 @@
+export default function getRenderFunc(variant) {
+  if (typeof variant === 'function') {
+    return variant;
+  }
+  return variant.render;
+}

--- a/src/browser/validateAndFilterExamples.js
+++ b/src/browser/validateAndFilterExamples.js
@@ -1,0 +1,22 @@
+import getRenderFunc from './getRenderFunc';
+
+export default function validateAndFilterExamples(examples) {
+  for (const example of examples) {
+    const variantKeys = Object.keys(example.variants);
+    for (const variantKey of variantKeys) {
+      const variant = example.variants[variantKey];
+      const renderFunc = getRenderFunc(variant);
+      if (!renderFunc) {
+        if (variantKey.startsWith('_')) {
+          delete example.variants[variantKey];
+        } else {
+          throw new Error(
+            `Variant ${variantKey} in component ${
+              example.component
+            } has no render function\nFound in ${example.fileName}`,
+          );
+        }
+      }
+    }
+  }
+}

--- a/test/integrations/error-test.js
+++ b/test/integrations/error-test.js
@@ -1,3 +1,5 @@
+import happoPluginPuppeteer from 'happo-plugin-puppeteer';
+
 import MockTarget from './MockTarget';
 import * as defaultConfig from '../../src/DEFAULTS';
 import makeRequest from '../../src/makeRequest';
@@ -29,4 +31,49 @@ it('throws on errors', async () => {
   }
   // If we end up here, something is wrong
   expect(false).toBe(true);
+});
+
+describe('with a misconfigured file', () => {
+  beforeEach(() => {
+    config.include = 'test/integrations/examples/*-error-misconfigured-happo.js*';
+    config.type = 'react';
+  });
+
+  it('throws an error', async () => {
+    try {
+      await subject();
+    } catch (e) {
+      expect(e.message).toMatch(
+        /Variant bar in component Foo-error-misconfigured has no render function/,
+      );
+      return;
+    }
+
+    console.log(config.targets.firefox.snapPayloads);
+
+    // If we end up here, something is wrong
+    expect(false).toBe(true);
+  });
+
+  describe('with the puppeteer plugin', () => {
+    beforeEach(() => {
+      config.plugins = [happoPluginPuppeteer()];
+    });
+
+    it('throws an error', async () => {
+      try {
+        await subject();
+      } catch (e) {
+        expect(e.message).toMatch(
+          /Variant bar in component Foo-error-misconfigured has no render function/,
+        );
+        return;
+      }
+
+      console.log(config.targets.firefox.snapPayloads);
+
+      // If we end up here, something is wrong
+      expect(false).toBe(true);
+    });
+  });
 });

--- a/test/integrations/examples/Foo-error-misconfigured-happo.js
+++ b/test/integrations/examples/Foo-error-misconfigured-happo.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default () => <div>Hello default!</div>;
+export const foo = () => <div>Hello foo!</div>;
+export const bar = <div>Hello foo!</div>;

--- a/test/integrations/examples/Generated-react-happo.js
+++ b/test/integrations/examples/Generated-react-happo.js
@@ -13,6 +13,9 @@ export default [
         stylesheets: ['two'],
       },
       three: () => <button>Three</button>,
+      _four: () => <button>Four</button>,
+      _ignored:
+        'Build tools sometimes add extra exports. There are usually prefixed with an underscore',
     },
   },
 ];

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -149,6 +149,12 @@ it('produces the right html', async () => {
       variant: 'three',
     },
     {
+      component: 'Generated',
+      css: '',
+      html: '<button>Four</button>',
+      variant: '_four',
+    },
+    {
       component: 'Plugin-Component',
       css: '',
       html: '<div>Hello world</div>',


### PR DESCRIPTION
This commit fixes a confusing bug that had different symptoms in
different DOM providers. Basically, a happo file that looked like this:

export const foo = () => <div>Hello</div>;
export const bar = <div>Hello</div>;

- would not render any examples in puppeteer
- would silently ignore `bar` in jsdom

The silent failure in puppeteer was because we were trying to serialize
something that wasn't serializable. And then puppeteer silently returns
undefined. This bug:
https://github.com/GoogleChrome/puppeteer/issues/242

The ignore in jsdom was because we had code in place to ignore
render-less exports (some build tools add these).

The fix is to yell loudly as soon as we come across an example that's
misconfigured. I did change the example ignore logic a little, now
there's an assumption that any special exports added by build tools will
start with an underscore. This is potentially a breaking change, but I'm
willing to gamble a little and call this a patch. The extra exports I've
seen in the past all had underscores.