### PR TITLE
Add `happo start-job` command, use it in happo-ci

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,8 @@ module.exports = {
     'no-restricted-syntax': 0,
     'react/no-multi-comp': 0,
     'class-methods-use-this': 0,
+    'no-nested-ternary': 0,
+    indent: 0,
   },
 
   globals: {

--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -8,6 +8,7 @@ set -eou pipefail
 
 # Initialize optional env variables
 INSTALL_CMD=${INSTALL_CMD:-}
+EXPECTED_PROJECTS=${EXPECTED_PROJECTS:-}
 
 # Make sure we use the full commit shas
 if [ ! -z "$PREVIOUS_SHA" ]; then
@@ -20,6 +21,7 @@ echo "PREVIOUS_SHA: ${PREVIOUS_SHA}"
 echo "CURRENT_SHA: ${CURRENT_SHA}"
 echo "CHANGE_URL: ${CHANGE_URL}"
 echo "INSTALL_CMD: ${INSTALL_CMD}"
+echo "EXPECTED_PROJECTS: ${EXPECTED_PROJECTS}"
 
 NPM_CLIENT="npm"
 NPM_CLIENT_FLAGS="--no-save"
@@ -65,6 +67,9 @@ if [ "$CURRENT_SHA" = "$PREVIOUS_SHA" ] || [ -z "$PREVIOUS_SHA" ]; then
   run-happo "$CURRENT_SHA"
   exit 0;
 fi
+
+"$NPM_BIN"/happo start-job "$PREVIOUS_SHA" "$CURRENT_SHA" \
+  --expected-projects="$EXPECTED_PROJECTS"
 
 # Check if we need to generate a baseline. In some cases, the baseline is
 # already there (some other PR uploaded it), and we can just use the existing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.12.1",
+  "version": "3.13.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.13.0-rc.2",
+  "version": "3.13.0-rc.3",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "prettier": {
-    "printWidth": 100,
+    "printWidth": 85,
     "singleQuote": true,
     "trailingComma": "all",
     "arrowParens": "always"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.13.0-rc.1",
+  "version": "3.13.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -31,7 +31,7 @@ export default class Logger {
   }
 
   info(msg) {
-    this.print(msg.replace(/https?:\/\/[^ ]+/g, underline));
+    this.print(`${msg}`.replace(/https?:\/\/[^ ]+/g, underline));
     this.print('\n');
   }
 

--- a/src/commands/startJob.js
+++ b/src/commands/startJob.js
@@ -3,7 +3,7 @@ import makeRequest from '../makeRequest';
 export default function startJob(
   sha1,
   sha2,
-  { apiKey, apiSecret, endpoint },
+  { apiKey, apiSecret, endpoint, project },
   { expectedProjects },
 ) {
   return makeRequest(
@@ -12,7 +12,7 @@ export default function startJob(
       method: 'POST',
       json: true,
       body: {
-        projects: expectedProjects ? expectedProjects.split(',') : undefined,
+        projects: expectedProjects ? expectedProjects.split(',') : [project],
       },
     },
     { apiKey, apiSecret },

--- a/src/commands/startJob.js
+++ b/src/commands/startJob.js
@@ -12,7 +12,11 @@ export default function startJob(
       method: 'POST',
       json: true,
       body: {
-        projects: expectedProjects ? expectedProjects.split(',') : [project],
+        projects: expectedProjects
+          ? expectedProjects.split(',')
+          : project
+          ? [project]
+          : undefined,
       },
     },
     { apiKey, apiSecret },

--- a/src/commands/startJob.js
+++ b/src/commands/startJob.js
@@ -1,0 +1,20 @@
+import makeRequest from '../makeRequest';
+
+export default function startJob(
+  sha1,
+  sha2,
+  { apiKey, apiSecret, endpoint },
+  { expectedProjects },
+) {
+  return makeRequest(
+    {
+      url: `${endpoint}/api/jobs/${sha1}/${sha2}`,
+      method: 'POST',
+      json: true,
+      body: {
+        projects: expectedProjects ? expectedProjects.split(',') : undefined,
+      },
+    },
+    { apiKey, apiSecret },
+  );
+}

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -10,6 +10,7 @@ import loadUserConfig from './loadUserConfig';
 import packageJson from '../package.json';
 import debugCommand from './commands/debug';
 import runCommand from './commands/run';
+import startJobCommand from './commands/startJob';
 import uploadReport from './uploadReport';
 
 commander
@@ -17,9 +18,17 @@ commander
   .option('-c, --config <path>', 'set config path', configFile)
   .option('-o, --only <component>', 'limit to one component')
   .option('-l, --link <url>', 'provide a link back to the commit')
-  .option('-m, --message <message>', 'associate the run with a message (e.g. commit subject)')
+  .option(
+    '-m, --message <message>',
+    'associate the run with a message (e.g. commit subject)',
+  )
   .option('-a, --author <email>', 'the author of the commit')
   .option('--debug-port <port>', 'the port where the debug server listens')
+  .option('--debug-port <port>', 'the port where the debug server listens')
+  .option(
+    '--expected-projects <projects>',
+    'a comma-separated list of projects to associate a job with',
+  )
   .usage('[options]');
 
 commander
@@ -28,7 +37,9 @@ commander
   .action(async (sha) => {
     let usedSha = sha || generateDevSha();
     if (!sha) {
-      new Logger().info(`No [sha] provided. A temporary one will be used in place: "${usedSha}".`);
+      new Logger().info(
+        `No [sha] provided. A temporary one will be used in place: "${usedSha}".`,
+      );
     }
     if (commander.only) {
       usedSha = `${usedSha}-${commander.only}`;
@@ -74,7 +85,9 @@ commander
   .command('empty <sha>')
   .description('mark a report as empty')
   .action(async (sha) => {
-    await uploadReport(Object.assign({ snaps: [], sha }, await loadUserConfig(commander.config)));
+    await uploadReport(
+      Object.assign({ snaps: [], sha }, await loadUserConfig(commander.config)),
+    );
     process.exit(0);
   });
 
@@ -82,17 +95,37 @@ commander
   .command('compare <sha1> <sha2>')
   .description('compare reports for two different shas')
   .action(async (sha1, sha2) => {
-    const result = await compareReportsCommand(sha1, sha2, await loadUserConfig(commander.config), {
-      link: commander.link,
-      message: commander.message,
-      author: commander.author,
-    });
+    const result = await compareReportsCommand(
+      sha1,
+      sha2,
+      await loadUserConfig(commander.config),
+      {
+        link: commander.link,
+        message: commander.message,
+        author: commander.author,
+      },
+    );
     new Logger().info(result.summary);
     if (result.equal) {
       process.exit(0);
     } else {
       process.exit(113);
     }
+  });
+
+commander
+  .command('start-job <sha1> <sha2>')
+  .description('start a job (used by happo-ci script)')
+  .action(async (sha1, sha2) => {
+    const result = await startJobCommand(
+      sha1,
+      sha2,
+      await loadUserConfig(commander.config),
+      {
+        expectedProjects: commander.expectedProjects,
+      },
+    );
+    new Logger().info(result.id);
   });
 
 export default function executeCli(argv) {


### PR DESCRIPTION
This command will tell happo.io about what to expect from the current ci
run. So far, it is best suited for a multi-project setups, where you
want to combine multiple happo runs in a single status.