### PR TITLE
Add support for remote rendering + an alternative way of posting statuses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
 
   globals: {
     document: true,
+    window: true,
   },
 };

--- a/README.md
+++ b/README.md
@@ -271,6 +271,11 @@ you need to set a few environment variables:
 
 ### Posting statuses back to PRs/commits
 
+*The instructions in this section only work if you are using github.com. If
+you're using a local Github Enterprise setup, there is an alternative solution
+described in the [next
+section](#posting-statuses-without-installing-the-happo-github-app)*
+
 By installing the [Happo Github App](https://github.com/apps/happo) and
 connecting to it on the [Github integration page on
 happo.io](https://happo.io/github-integration), you allow Happo to update the
@@ -292,6 +297,27 @@ installed and connected on
 need to make sure that you provide a `--link <url>` with your calls to `happo
 compare`. If you're using any of the standard CI scripts listed above, the
 `--link` is automatically taken care of for you.
+
+### Posting statuses without installing the Happo Github App
+
+If you for some reason can't install the Happo Github App (e.g. when using
+Github Enterprise) you can still get the Happo status posted to your PR -- as a
+comment on the pull request. To get this working, you have to provide the Happo
+CI script with user credentials containing a username and a personal access
+token, through `HAPPO_GITHUB_USER_CREDENTIALS`. E.g.
+
+```bash
+HAPPO_GITHUB_USER_CREDENTIALS="trotzig:21A4XgnSkt7f36ehlK5"
+```
+[Here's a guide from
+github.com](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
+on how to generate the personal token.
+
+The environment variable must contain both the username of the profile and the
+personal access token, separated by a colon.
+
+If you're using Github Enterprise, apart from defining the environment variable
+you also need to add [`githubApiUrl` to `.happo.js`](#githubapiurl).
 
 ## Defining examples
 
@@ -893,6 +919,15 @@ module.exports = {
   asyncTimeout: 500,
 }
 ```
+
+### `githubApiUrl`
+
+Used when you have the CI script configured to [post Happo statuses as
+comments](#posting-statuses-without-installing-the-happo-github-app).
+The default if `https://api.github.com`. If you're using Github Enterprise,
+enter the URL to the local Github API here, e.g.
+`https://ghe.mycompany.zone/api/v3` (the default for GHE installation is for
+the API to be located at `/api/v3`).
 
 ## Command-Line-Interface (CLI)
 

--- a/README.md
+++ b/README.md
@@ -786,6 +786,22 @@ module.exports = {
 }
 ```
 
+### `prerender` (experimental)
+
+Controls whether or not examples are pre-rendered in a JSDOM environment (or
+Chrome if you are using
+[happo-plugin-puppeteer](https://github.com/happo/happo-plugin-puppeteer)). The
+default is `true`. Set to `false` to let your examples render remotely on the
+happo.io browser workers instead. This can help resolve certain rendering
+issues (e.g. when using a shadow DOM). The downside of rendering remotely is
+that errors are harder to surface.
+
+```js
+module.exports = {
+  prerender: false,
+}
+```
+
 ### `setupScript`
 
 An absolute path to a file that will be executed before rendering your

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.14.0-rc.1",
+  "version": "3.14.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.14.0-rc.4",
+  "version": "3.14.0-rc.5",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.13.1",
+  "version": "3.14.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.14.0-rc.3",
+  "version": "3.14.0-rc.4",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.14.0-rc.2",
+  "version": "3.14.0-rc.3",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -26,6 +26,7 @@ export const prerender = true;
 export const publicFolders = [];
 export const tmpdir = path.join(os.tmpdir(), cwdUniqueFolderName);
 export const renderWrapperModule = require.resolve('./renderWrapper');
+export const githubApiUrl = 'https://api.github.com';
 export function customizeWebpackConfig(config) {
   // provide a default no-op for this config option so that we can assume it's
   // always there.

--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -22,6 +22,7 @@ export const asyncTimeout = 200;
 export const configFile = './.happo.js';
 export const type = 'react';
 export const plugins = [];
+export const prerender = true;
 export const publicFolders = [];
 export const tmpdir = path.join(os.tmpdir(), cwdUniqueFolderName);
 export const renderWrapperModule = require.resolve('./renderWrapper');

--- a/src/browser/remoteRenderer.js
+++ b/src/browser/remoteRenderer.js
@@ -1,0 +1,9 @@
+window.happo = window.happo || {};
+
+window.happo.initChunk = () => {};
+window.happo.nextExample = () => {
+  if (!window.happoProcessor.next()) {
+    return;
+  }
+  return window.happoProcessor.processCurrent();
+};

--- a/src/browser/remoteRenderer.js
+++ b/src/browser/remoteRenderer.js
@@ -3,7 +3,7 @@ window.happo = window.happo || {};
 window.happo.initChunk = () => {};
 window.happo.nextExample = () => {
   if (!window.happoProcessor.next()) {
-    return;
+    return Promise.resolve(undefined);
   }
   return window.happoProcessor.processCurrent();
 };

--- a/src/browser/validateAndFilterExamples.js
+++ b/src/browser/validateAndFilterExamples.js
@@ -1,22 +1,20 @@
 import getRenderFunc from './getRenderFunc';
 
 export default function validateAndFilterExamples(examples) {
-  for (const example of examples) {
-    const variantKeys = Object.keys(example.variants);
-    for (const variantKey of variantKeys) {
-      const variant = example.variants[variantKey];
-      const renderFunc = getRenderFunc(variant);
+  return examples
+    .map((example) => {
+      const renderFunc = getRenderFunc(example.render);
       if (!renderFunc) {
-        if (variantKey.startsWith('_')) {
-          delete example.variants[variantKey];
-        } else {
-          throw new Error(
-            `Variant ${variantKey} in component ${
-              example.component
-            } has no render function\nFound in ${example.fileName}`,
-          );
+        if (example.variant.startsWith('_')) {
+          return undefined;
         }
+        throw new Error(
+          `Variant ${example.variant} in component ${
+            example.component
+          } has no render function\nFound in ${example.fileName}`,
+        );
       }
-    }
-  }
+      return example;
+    })
+    .filter(Boolean);
 }

--- a/src/createDynamicEntryPoint.js
+++ b/src/createDynamicEntryPoint.js
@@ -13,6 +13,7 @@ export default async function createDynamicEntryPoint({
   only,
   type,
   plugins,
+  prerender,
   tmpdir,
   rootElementSelector,
   renderWrapperModule,
@@ -63,10 +64,15 @@ export default async function createDynamicEntryPoint({
     `.trim(),
     );
   }
+
   if (setupScript) {
     strings.push(`require('${setupScript}');`);
   }
   strings.push(...fileStrings);
+  if (!prerender) {
+    const pathToRemoteRenderer = require.resolve('./browser/remoteRenderer');
+    strings.push(`require('${pathToRemoteRenderer}');`);
+  }
   strings.push('window.onBundleReady && window.onBundleReady();');
   const entryFile = path.join(tmpdir, 'happo-entry.js');
 

--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -12,9 +12,9 @@ const IFRAME_CONTENT = `
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="happo-bundle.js"></script>
   </head>
   <body>
+    <script src="happo-bundle.js"></script>
   </body>
 </html>
 `;

--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -1,0 +1,62 @@
+import { Writable } from 'stream';
+import fs from 'fs';
+
+import Archiver from 'archiver';
+
+// We're setting the creation date to the same for all files so that the zip
+// packages created for the same content ends up having the same fingerprint.
+const FILE_CREATION_DATE = new Date('Fri Feb 08 2019 13:31:55 GMT+0100 (CET)');
+
+const IFRAME_CONTENT = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="happo-bundle.js"></script>
+  </head>
+  <body>
+  </body>
+</html>
+`;
+
+export default function createStaticPackage({ bundleFile, publicFolders }) {
+  return new Promise((resolve, reject) => {
+    const archive = new Archiver('zip');
+
+    const stream = new Writable();
+    const data = [];
+
+    // eslint-disable-next-line no-underscore-dangle
+    stream._write = (chunk, enc, done) => {
+      data.push(...chunk);
+      done();
+    };
+    stream.on('finish', () => {
+      const buffer = Buffer.from(data);
+      resolve(buffer);
+    });
+    archive.pipe(stream);
+
+    archive.append(fs.createReadStream(bundleFile), {
+      name: 'happo-bundle.js',
+      date: FILE_CREATION_DATE,
+    });
+
+    archive.append(IFRAME_CONTENT, {
+      name: 'iframe.html',
+      date: FILE_CREATION_DATE,
+    });
+
+    publicFolders.forEach((folder) => {
+      if (!folder.startsWith(process.cwd())) {
+        throw new Error(
+          `Public folder ${folder} is not a descendant of cwd (${process.cwd})`,
+        );
+      }
+      archive.directory(folder.slice(process.cwd().length + 1));
+    });
+
+    archive.on('error', reject);
+    archive.finalize();
+  });
+}

--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -48,12 +48,9 @@ export default function createStaticPackage({ bundleFile, publicFolders }) {
     });
 
     publicFolders.forEach((folder) => {
-      if (!folder.startsWith(process.cwd())) {
-        throw new Error(
-          `Public folder ${folder} is not a descendant of cwd (${process.cwd})`,
-        );
+      if (folder.startsWith(process.cwd())) {
+        archive.directory(folder.slice(process.cwd().length + 1));
       }
-      archive.directory(folder.slice(process.cwd().length + 1));
     });
 
     archive.on('error', reject);

--- a/src/debug.html
+++ b/src/debug.html
@@ -25,15 +25,15 @@
         const results = [];
         while (happoProcessor.next()) {
           const result = await happoProcessor.processCurrent();
-          results.push(...result);
+          results.push(result);
         }
         summarize(results);
       }
 
       async function renderOne(index) {
         happoProcessor.cursor = index;
-        const results = await happoProcessor.processCurrent();
-        summarize(results);
+        const result = await happoProcessor.processCurrent();
+        summarize([result]);
       }
 
       async function populateList() {
@@ -41,7 +41,7 @@
         happoProcessor.flattenedExamples.forEach((example, i) => {
           const li = document.createElement('li');
           li.innerHTML = `
-          ${example.component} <button onclick="renderOne(${i})">render</button>
+          ${example.component}-${example-variant} <button onclick="renderOne(${i})">render</button>
           `;
           allUl.appendChild(li)
         });

--- a/src/postGithubComment.js
+++ b/src/postGithubComment.js
@@ -1,0 +1,49 @@
+import request from 'request-promise-native';
+
+import Logger from './Logger';
+
+const REPO_URL_MATCHER = /https?:\/\/[^/]+\/([^/]+)\/([^/]+)\/pull\/([0-9]+)/;
+// https://github.com/lightstep/lightstep/pull/6555
+
+const { HAPPO_GITHUB_USER_CREDENTIALS } = process.env;
+
+export default async function postGithubComment({
+  statusImageUrl,
+  compareUrl,
+  link,
+  githubApiUrl,
+  userCredentials = HAPPO_GITHUB_USER_CREDENTIALS,
+}) {
+  const matches = link.match(REPO_URL_MATCHER);
+  if (!matches) {
+    new Logger().info(
+      `URL does not look like a github PR URL: ${link}. Skipping github comment posting...`,
+    );
+    return false;
+  }
+
+  const [user, pass] = userCredentials.split(':');
+
+  const owner = matches[1];
+  const repo = matches[2];
+  const prNumber = matches[3];
+
+  const normalizedGithubApiUrl = githubApiUrl.replace(/\/$/, '');
+
+  await request({
+    url: `${normalizedGithubApiUrl}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+    method: 'POST',
+    json: true,
+    headers: {
+      'User-Agent': 'happo.io client',
+    },
+    auth: {
+      user,
+      pass,
+    },
+    body: {
+      body: `[![Happo status](${statusImageUrl})](${compareUrl})`,
+    },
+  });
+  return true;
+}

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -23,8 +23,8 @@ export default async function processSnapsInBundle(
       if (VERBOSE === 'true') {
         console.log(`Viewport ${viewport}`);
       }
-      const payloads = await domProvider.processCurrent();
-      result.snapPayloads.push(...payloads);
+      const payload = await domProvider.processCurrent();
+      result.snapPayloads.push(payload);
     }
 
     result.css = await domProvider.extractCSS();

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -204,3 +204,44 @@ button { color: red }`,
     },
   ]);
 });
+
+it('works with prerender=false', async () => {
+  config.prerender = false;
+  config.publicFolders = [path.resolve(__dirname, 'assets')];
+  await subject();
+  expect(config.targets.chrome.globalCSS).toEqual([
+    {
+      css: '.a { b: c }\n',
+      source: path.resolve(__dirname, 'styles.css'),
+    },
+    {
+      id: 'one',
+      conditional: true,
+      source: path.resolve(__dirname, 'one.css'),
+      css: `button {
+  background-image: url(assets/one.jpg);
+  border: 2px solid black;
+  border-radius: 5px;
+}
+`,
+    },
+    {
+      css: `button {
+  background-color: green;
+  color: white;
+}
+`,
+      source: path.resolve(__dirname, 'two.css'),
+    },
+    { css: '.plugin-injected { color: red }' },
+  ]);
+
+  const zip = new AdmZip(config.targets.chrome.staticPackage);
+  expect(zip.getEntries().map(({ entryName }) => entryName)).toEqual([
+    'happo-bundle.js',
+    'iframe.html',
+    'test/integrations/assets/one.jpg',
+  ]);
+  // require('fs').writeFileSync('staticPackage.zip',
+  //   Buffer.from(config.targets.chrome.staticPackage, 'base64'));
+});

--- a/test/postGithubComment-test.js
+++ b/test/postGithubComment-test.js
@@ -1,0 +1,74 @@
+import request from 'request-promise-native';
+
+import postGithubComment from '../src/postGithubComment';
+
+jest.mock('request-promise-native');
+
+let subject;
+let githubApiUrl;
+let compareUrl;
+let statusImageUrl;
+let userCredentials;
+let link;
+
+beforeEach(() => {
+  request.mockReset();
+  githubApiUrl = 'https://api.ghe.com';
+  compareUrl = 'https://foo.bar/foo/bar';
+  statusImageUrl = 'https://foo.bar/foo/bar/status.svg';
+  link = 'https://github.com/happo/happo-view/pull/156';
+  userCredentials = 'foo:bar';
+
+  subject = () =>
+    postGithubComment({
+      link,
+      compareUrl,
+      statusImageUrl,
+      githubApiUrl,
+      userCredentials,
+    });
+});
+
+it('posts a comment', async () => {
+  await subject();
+  const { auth, body, method, url } = request.mock.calls[0][0];
+  expect(url).toEqual(
+    'https://api.ghe.com/repos/happo/happo-view/issues/156/comments',
+  );
+  expect(body.body).toEqual(
+    '[![Happo status](https://foo.bar/foo/bar/status.svg)](https://foo.bar/foo/bar)',
+  );
+  expect(auth).toEqual({ user: 'foo', pass: 'bar' });
+  expect(method).toEqual('POST');
+});
+
+it('returns true', async () => {
+  expect(await subject()).toBe(true);
+});
+
+describe('when githubApiUrl ends with a slash', () => {
+  beforeEach(() => {
+    githubApiUrl = 'https://ghe.com/api/v3/';
+  });
+
+  it('constructs a correct URL', async () => {
+    await subject();
+    const { url } = request.mock.calls[0][0];
+    expect(url).toEqual(
+      'https://ghe.com/api/v3/repos/happo/happo-view/issues/156/comments',
+    );
+  });
+});
+
+describe('when the link does not match a PR url', () => {
+  beforeEach(() => {
+    link = 'https://github.com/happo/happo-view/issues/156';
+  });
+
+  it('does not post anything', async () => {
+    const result = await subject();
+    expect(result).toBe(false);
+
+    expect(request.mock.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
By default, examples are pre-rendered in jsdom (or puppeteer when the
happo-plugin-puppeteer plugin is used). There are a few reasons we do
this:
- easier to surface errors to the user
- slightly better performance (although it was a long time since I
measured)
- no javascript code is shipped over the wire (instead, only html+css)

In the majority of cases, this approach is just fine. But recently I've
started coming across more and more cases where pre-rendering is making
things difficult. For custom web elements using the shadow dom,
pre-rendering is pretty much not working. To mitigate that, I'm
introducing a `prerender` configuration option. The default will be
`true`. By setting it to false, you leave rendering up to the happo.io
workers.

Also in this PR: a way to get happo statuses posted to PRs without using the github happo app. 