### PR TITLE
Allow setting `maxHeight` for browser target

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -2,13 +2,13 @@ const RemoteBrowserTarget = require('./build/RemoteBrowserTarget').default;
 
 module.exports = {
   pages: [
-    { url: 'https://www.google.com/', title: 'Google' },
     { url: 'https://beteendelabbet.se/', title: 'Beteendelabbet' },
   ],
   targets: {
     'chrome-large': new RemoteBrowserTarget('chrome', {
       viewport: '800x600',
       chunks: 2,
+      maxHeight: 10000,
     }),
   },
 };

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-jest": "^21.15.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
-    "happo-plugin-puppeteer": "^1.3.0",
+    "happo-plugin-puppeteer": "^1.3.1",
     "jest": "^22.4.3",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -22,7 +22,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
 const MIN_INTERNET_EXPLORER_WIDTH = 400;
 
 export default class RemoteBrowserTarget {
-  constructor(browserName, { viewport, chunks = 1 }) {
+  constructor(browserName, { viewport, chunks = 1, maxHeight }) {
     const viewportMatch = viewport.match(VIEWPORT_PATTERN);
     if (!viewportMatch) {
       throw new Error(
@@ -41,6 +41,7 @@ export default class RemoteBrowserTarget {
     this.chunks = chunks;
     this.browserName = browserName;
     this.viewport = viewport;
+    this.maxHeight = maxHeight;
   }
 
   async execute({
@@ -63,6 +64,7 @@ export default class RemoteBrowserTarget {
             type: `browser-${this.browserName}`,
             payload: {
               viewport: this.viewport,
+              maxHeight: this.maxHeight,
               globalCSS,
               snapPayloads: slice,
               chunk,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3141,10 +3141,10 @@ handlebars@^4.0.3:
   optionalDependencies:
     uglify-js "^2.6"
 
-happo-plugin-puppeteer@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/happo-plugin-puppeteer/-/happo-plugin-puppeteer-1.3.0.tgz#1bf252b16aff0629db6e87ae6aa3126b74b98df7"
-  integrity sha512-PcBqfIZ/UhWS16P7z7cu/gfg/4q1G0iJJlim4HwTiFeH4rkLl4WENEb0ol6c5orCwrB/1VGJdbYkRTvsrMiEIg==
+happo-plugin-puppeteer@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/happo-plugin-puppeteer/-/happo-plugin-puppeteer-1.3.1.tgz#f976aade4bdbf56b44734de9cac56af859bfbde7"
+  integrity sha512-Vj+KOW2yrkVbjKF9SvaoAR1bSPzynFQVTLnnbwwYDRbrJy2wod0z9whYuTyWIrpqxxUL1fC5Zbmi1fl4bfcyIQ==
   dependencies:
     puppeteer "^1.14.0"
 


### PR DESCRIPTION
The default cutoff point on happo workers is 5000px. Any example larger
than that will be cropped. Now that we have full-page support, this
number is starting to feel a little small. But instead of globally
bumping it I'm making a change to RemoteBrowserTarget that will allow
you to set a custom maxHeight.