### PR TITLE
Allow different base branch than master in CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ jobs:
           command: npm run happo-ci-circleci
 ```
 
+The `happo-ci-circleci` script assumes your PRs are based off of the master
+branch. If you're using a different default branch, you can set the
+`BASE_BRANCH` environment variable.
+
+```json
+{
+  "scripts": {
+    "happo": "happo",
+    "happo-ci-circleci": "BASE_BRANCH=\"origin/dev\" happo-ci-circleci"
+  }
+}
+```
+
 ### `happo-ci`
 
 This is a generic script that can run in most CI environments. Before using it,

--- a/bin/happo-ci-circleci
+++ b/bin/happo-ci-circleci
@@ -3,7 +3,10 @@
 # Make the whole script fail on errors
 set -euo pipefail
 
-PREVIOUS_SHA=$(git merge-base origin/master "${CIRCLE_SHA1}")
+BASE_BRANCH=${BASE_BRANCH:-"origin/master"}
+echo "Using ${BASE_BRANCH} as the base branch"
+PREVIOUS_SHA=$(git merge-base "${BASE_BRANCH}" "${CIRCLE_SHA1}")
+
 export PREVIOUS_SHA
 export CURRENT_SHA="${CIRCLE_SHA1}"
 


### PR DESCRIPTION
Up until now all projects have been using origin/master as the base
branch. In the Rocket.Chat repository however, the base branch is
`develop`. By allowing people to override the default origin/master
through an environment variable, we support projects like these as well.

https://github.com/RocketChat/Rocket.Chat/branches

Fixes #79