### PR TITLE
Allow HAPPO_CONFIG_FILE env variable to specify path to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,8 +761,9 @@ module.exports = {
 
 Happo will look for configuration in a `.happo.js` file in the current working
 folder. You can override the path to this file through the `--config` CLI
-option. This file isn't subject to babel transpilation, so it's best to stay
-with good old CommonJS syntax unless you're on the very latest Node version.
+option or a `HAPPO_CONFIG_FILE` environment variable. The config file isn't
+subject to babel transpilation, so it's best to stay with good old CommonJS
+syntax unless you're on the very latest Node version.
 
 ## `project`
 

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -35,7 +35,11 @@ export default async function loadUserConfig(
   pathToConfigFile,
   env = process.env,
 ) {
-  const { CHANGE_URL } = env;
+  const { CHANGE_URL, HAPPO_CONFIG_FILE } = env;
+
+  if (HAPPO_CONFIG_FILE) {
+    pathToConfigFile = HAPPO_CONFIG_FILE;
+  }
 
   const config = load(pathToConfigFile);
   if (!config.apiKey || !config.apiSecret) {

--- a/test/.happo-alternate.js
+++ b/test/.happo-alternate.js
@@ -1,0 +1,8 @@
+module.exports = {
+  type: 'plain',
+  targets: {
+    foo: {},
+  },
+  apiKey: 'tom',
+  apiSecret: 'dooner',
+};

--- a/test/loadUserConfig-test.js
+++ b/test/loadUserConfig-test.js
@@ -5,6 +5,8 @@ import Logger from '../src/Logger';
 import RemoteBrowserTarget from '../src/RemoteBrowserTarget';
 import loadUserConfig from '../src/loadUserConfig';
 
+const actualRequireRelative = jest.requireActual('require-relative');
+
 jest.mock('request-promise-native');
 jest.mock('require-relative');
 jest.mock('../src/Logger');
@@ -50,6 +52,18 @@ it('does not yell if all required things are in place', async () => {
   expect(config.apiSecret).toEqual('2');
   expect(config.targets).toEqual({
     firefox: new RemoteBrowserTarget('firefox', { viewport: '800x600' }),
+  });
+});
+
+describe('when HAPPO_CONFIG_URL is defined', () => {
+  beforeEach(() => {
+    requireRelative.mockImplementation(actualRequireRelative);
+  });
+
+  it('uses config from that file', async () => {
+    const config = await loadUserConfig('bogus', { HAPPO_CONFIG_FILE: './test/.happo-alternate.js' });
+    expect(config.apiKey).toEqual('tom');
+    expect(config.apiSecret).toEqual('dooner');
   });
 });
 


### PR DESCRIPTION
We already have the `--config` option for the CLI tool, but that doesn't
work in the ci scripts. To allow a config override to pierce through to
the different `happo` ci invocations, I'm adding support for an env
variable.