### PR TITLE
Allow async user configs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,5 @@
       }
     }]
   ],
-  "plugins": ["babel-plugin-syntax-dynamic-import"]
+  "plugins": ["babel-plugin-syntax-dynamic-import", "babel-plugin-transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-jest": "^22.4.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -9,8 +9,8 @@ async function load(pathToConfigFile) {
   try {
     let userConfig = requireRelative(pathToConfigFile, process.cwd());
     //await if the config is a function, async or not
-    if(typeof userConfig === 'function'){
-        userConfig = await userConfig();
+    if (typeof userConfig === 'function') {
+      userConfig = await userConfig();
     }
     return Object.assign({}, defaultConfig, userConfig);
   } catch (e) {

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -5,9 +5,10 @@ import Logger from './Logger';
 import WrappedError from './WrappedError';
 import * as defaultConfig from './DEFAULTS';
 
-function load(pathToConfigFile) {
+async function load(pathToConfigFile) {
   try {
-    return Object.assign({}, defaultConfig, requireRelative(pathToConfigFile, process.cwd()));
+    const userConfig = await Promise.resolve(requireRelative(pathToConfigFile, process.cwd()));
+    return Object.assign({}, defaultConfig, userConfig);
   } catch (e) {
     // We only check for the default config file here, so that a missing custom
     // config path isn't ignored.
@@ -41,7 +42,7 @@ export default async function loadUserConfig(
     pathToConfigFile = HAPPO_CONFIG_FILE;
   }
 
-  const config = load(pathToConfigFile);
+  const config = await load(pathToConfigFile);
   if (!config.apiKey || !config.apiSecret) {
     if (!CHANGE_URL) {
       throw new Error(

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -12,7 +12,7 @@ async function load(pathToConfigFile) {
     if (typeof userConfig === 'function') {
       userConfig = await userConfig();
     }
-    return Object.assign({}, defaultConfig, userConfig);
+    return { ...defaultConfig, ...userConfig };
   } catch (e) {
     // We only check for the default config file here, so that a missing custom
     // config path isn't ignored.

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -8,7 +8,7 @@ import * as defaultConfig from './DEFAULTS';
 async function load(pathToConfigFile) {
   try {
     let userConfig = requireRelative(pathToConfigFile, process.cwd());
-    //await if the config is a function, async or not
+    // await if the config is a function, async or not
     if (typeof userConfig === 'function') {
       userConfig = await userConfig();
     }

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -7,7 +7,11 @@ import * as defaultConfig from './DEFAULTS';
 
 async function load(pathToConfigFile) {
   try {
-    const userConfig = await Promise.resolve(requireRelative(pathToConfigFile, process.cwd()));
+    let userConfig = requireRelative(pathToConfigFile, process.cwd());
+    //await if the config is a function, async or not
+    if(typeof userConfig === 'function'){
+        userConfig = await userConfig();
+    }
     return Object.assign({}, defaultConfig, userConfig);
   } catch (e) {
     // We only check for the default config file here, so that a missing custom

--- a/test/.happo-alternate-async.js
+++ b/test/.happo-alternate-async.js
@@ -1,10 +1,14 @@
-module.exports = async () => {
-  return {
-    type: 'plain',
-    targets: {
-      foo: {},
-    },
-    apiKey: 'tom',
-    apiSecret: 'dooner',
-  };
+module.exports = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        type: 'plain',
+        targets: {
+          foo: {},
+        },
+        apiKey: 'tom',
+        apiSecret: 'dooner',
+      });
+    }, 10);
+  });
 };

--- a/test/.happo-alternate-async.js
+++ b/test/.happo-alternate-async.js
@@ -1,0 +1,10 @@
+module.exports = async () => {
+  return {
+    type: 'plain',
+    targets: {
+      foo: {},
+    },
+    apiKey: 'tom',
+    apiSecret: 'dooner',
+  };
+};

--- a/test/loadUserConfig-test.js
+++ b/test/loadUserConfig-test.js
@@ -65,6 +65,12 @@ describe('when HAPPO_CONFIG_URL is defined', () => {
     expect(config.apiKey).toEqual('tom');
     expect(config.apiSecret).toEqual('dooner');
   });
+
+  it('allows async config', async () => {
+    const config = await loadUserConfig('bogus', { HAPPO_CONFIG_FILE: './test/.happo-alternate-async.js' });
+    expect(config.apiKey).toEqual('tom');
+    expect(config.apiSecret).toEqual('dooner');
+  });
 });
 
 describe('when CHANGE_URL is defined', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,7 +933,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   resolved "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
@@ -1158,6 +1158,14 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"


### PR DESCRIPTION
This PR changes how the `.happo.js` config file is loaded. It allows asynchronous execution within the config file itself to do things such as spinning up a static file server or exposing ports to services like localtunnel or ngrok.

Simple example:
```javascript
const path = require('path');
const ngrok = require('ngrok');
const { RemoteBrowserTarget } = require('happo.io');

module.exports = new Promise(async (resolve) => {

    const url = await ngrok.connect(9090);
    
    resolve({
        apiKey: process.env.HAPPO_API_KEY,
        apiSecret: process.env.HAPPO_API_SECRET,

        targets: {
            'chrome-desktop': new RemoteBrowserTarget('chrome', {
                viewport: '1366x768',
            }),
        },
    });
});
```