### PR TITLE
Stop no-op:ing cancelAnimationFrame

### DIFF
--- a/src/JSDOMDomProvider.js
+++ b/src/JSDOMDomProvider.js
@@ -46,7 +46,7 @@ export default class JSDOMDomProvider {
               availHeight: { value: height },
             });
             win.requestAnimationFrame = (callback) => setTimeout(callback, 0);
-            win.cancelAnimationFrame = () => {};
+            win.cancelAnimationFrame = clearTimeout;
           },
         },
         jsdomOptions,

--- a/test/integrations/examples/Foo-react-happo.js
+++ b/test/integrations/examples/Foo-react-happo.js
@@ -107,3 +107,41 @@ export const themedExampleAsync = (renderInDom) => {
   );
   return new Promise((resolve) => setTimeout(resolve, 20));
 };
+
+class RAFExample extends React.Component {
+  async componentDidMount() {
+    window.requestAnimationFrame(() => {
+      this.setState({ label: 'Loaded' });
+    });
+  }
+
+  render() {
+    if (!this.state) {
+      return null;
+    }
+    return <div>{this.state.label}</div>;
+  }
+}
+
+export const rafExample = () => <RAFExample />;
+
+class RAFUnmountExample extends React.Component {
+  async componentDidMount() {
+    this.raf = window.requestAnimationFrame(() => {
+      document.title = 'Foobar';
+    });
+  }
+
+  componentWillUnmount() {
+    window.cancelAnimationFrame(this.raf);
+  }
+
+  render() {
+    if (!this.state) {
+      return <div>Not loaded</div>;
+    }
+    return <div>{this.state.label}</div>;
+  }
+}
+
+export const rafUnmountExample = () => <RAFUnmountExample />;

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -126,6 +126,18 @@ it('produces the right html', async () => {
     {
       component: 'Foo-react',
       css: '',
+      html: '<div>Loaded</div>',
+      variant: 'rafExample',
+    },
+    {
+      component: 'Foo-react',
+      css: '',
+      html: '<div>Not loaded</div>',
+      variant: 'rafUnmountExample',
+    },
+    {
+      component: 'Foo-react',
+      css: '',
       html: '<button>Click me</button>',
       variant: 'default',
     },
@@ -175,7 +187,7 @@ describe('with the puppeteer plugin', () => {
 
   it('produces the right number of snaps', async () => {
     await subject();
-    expect(config.targets.chrome.snapPayloads.length).toBe(16);
+    expect(config.targets.chrome.snapPayloads.length).toBe(18);
   });
 });
 


### PR DESCRIPTION
This behavior is leading to unexpected and unwanted behavior where a
component calling cancelAnimationFrame on unmounting could lead to
issues in jsdom where the document is no longer defined.