### PR TITLE
Make domRunner "Reading files" log more specific

### DIFF
--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -225,7 +225,7 @@ export default async function domRunner(
     plugins,
   });
   const logger = new Logger();
-  logger.start('Reading files...');
+  logger.start('Searching for happo test files...');
   let entryFile;
   try {
     const entryPointResult = await createDynamicEntryPoint({


### PR DESCRIPTION
"Reading files" is really vague, so it is hard to know what happo is
doing here, and when it goes wrong it can be hard to know how to fix it.