### PR TITLE
Use `-n` instead of `! -z` in bin/happo-ci

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -10,7 +10,7 @@ set -eou pipefail
 INSTALL_CMD=${INSTALL_CMD:-}
 
 # Make sure we use the full commit shas
-if [ ! -z "$PREVIOUS_SHA" ]; then
+if [ -n "$PREVIOUS_SHA" ]; then
   PREVIOUS_SHA="$(git rev-parse "$PREVIOUS_SHA")"
 fi
 CURRENT_SHA="$(git rev-parse "$CURRENT_SHA")"


### PR DESCRIPTION
I spotted this stylistic issue after running this script
through shellcheck. More info:

  https://github.com/koalaman/shellcheck/wiki/SC2236