### PR TITLE
Improve finding the root node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "3.21.2",
+  "version": "3.22.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/browser/processor.js
+++ b/src/browser/processor.js
@@ -9,27 +9,27 @@ import validateAndFilterExamples from './validateAndFilterExamples';
 const ROOT_ELEMENT_ID = 'happo-root';
 
 function findRoot() {
-  // Grab the element that we add to the dom by default. This element will
-  // usually be the right element, at least in the react case.
-  const root = document.getElementById(ROOT_ELEMENT_ID);
+  const { children } = document.body;
 
-  if (!root) {
-    // The root element may very well have been overridden in the render method
-    // for an example. In that case, fall back to the <body> element.
+  // Find nodes that have some inner content and aren't script nodes.
+  const layoutChildren = Array.from(children).filter(
+    (node) => node.tagName.toLowerCase() !== 'script' && node.innerHTML !== '',
+  );
+
+  if (layoutChildren.length === 0) {
+    // None of the children have content. Use the default root element or fall
+    // back to the first child.
+    return document.getElementById(ROOT_ELEMENT_ID) || children[0];
+  }
+
+  if (layoutChildren.length > 1) {
+    // When multiple elements have content, use the body as the root (thus
+    // forcing all elements to be included in the captured html).
     return document.body;
   }
 
-  if (root.innerHTML === '') {
-    // The root has no content. Which means we're potentially rendering to a
-    // portal element. Iterate through other root elements to see if any other
-    // has content.
-    for (const potentialRoot of document.body.children) {
-      if (potentialRoot.innerHTML !== '') {
-        return potentialRoot;
-      }
-    }
-  }
-  return root;
+  // Only one child has content. Use it!
+  return layoutChildren[0];
 }
 
 async function renderExample(exampleRenderFunc) {

--- a/test/integrations/examples/Foo-react-happo.js
+++ b/test/integrations/examples/Foo-react-happo.js
@@ -34,6 +34,15 @@ export const portalExample = () => (
   </PortalComponent>
 );
 
+export const innerPortal = () => (
+  <React.Fragment>
+    <div>Outside portal</div>
+    <PortalComponent>
+      Inside portal
+    </PortalComponent>
+  </React.Fragment>
+);
+
 class AsyncComponent extends React.Component {
   constructor(props) {
     super(props);

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -90,6 +90,13 @@ it('produces the right html', async () => {
     {
       component: 'Foo-react',
       css: '',
+      html:
+      '<div id="happo-root"><div>Outside portal</div></div><div>Inside portal</div>',
+      variant: 'innerPortal',
+    },
+    {
+      component: 'Foo-react',
+      css: '',
       html: '<button>Ready</button>',
       variant: 'asyncExample',
     },
@@ -187,7 +194,7 @@ describe('with the puppeteer plugin', () => {
 
   it('produces the right number of snaps', async () => {
     await subject();
-    expect(config.targets.chrome.snapPayloads.length).toBe(18);
+    expect(config.targets.chrome.snapPayloads.length).toBe(19);
   });
 });
 


### PR DESCRIPTION
Fixes #95.

Before, when an example renders to multiple DOM nodes, we would just
include one of them in the html snapshot. In many cases, this led to
empty/blank screenshots. Consider this html:

```html
<body>
  <div id="happo-root"><div></div></div>
  <div>
    I'm in a portal!
  </div>
</body>
```

With the old findRoot() implementation, only the inner div of
`#happo-root` would be included in the html snapshot. With the new
implementation, both elements would be included:

```html
<div id="happo-root"><div></div></div>
<div>
  I'm in a portal!
</div>
</html>

This change is a little delicate as we have to be careful about
including too much in the html snapshot. For instance, if a React
component only renders to a portal, we don't want to include the empty
root:

this
```html
<body>
  <div id="happo-root"></div>
  <div>
    I'm in a portal!
  </div>
</body>
```

should result in
```html
<div>
  I'm in a portal!
</div>
```

Why is this important? Because we want to keep screenshots as small as
possible, and by including outer divs we (usually) end up with page-wide
screenshots. If we have the portal render in a narrow container, the
empty `#happo-root` div would cause the screenshot to be full-width.

this
```
<body>
  <div id="happo-root"></div>
  <div style="width: 100px">
    I'm in a portal!
  </div>
</body>
```

should produce a screenshot that is 100px wide. If we were to include
`#happo-root` here, the screenshot would be as wide as the viewport is
(unless there's some css preventing default div styling to apply to
`#happo-root`).