### PR TITLE
Fix bug in jsdomError handling when e.detail is undefined

### DIFF
--- a/src/JSDOMDomProvider.js
+++ b/src/JSDOMDomProvider.js
@@ -8,13 +8,13 @@ export default class JSDOMDomProvider {
   constructor(jsdomOptions, { width, height, webpackBundle }) {
     const virtualConsole = new VirtualConsole();
     virtualConsole.on('jsdomError', (e) => {
-      const len = e.detail.length;
-      if (VERBOSE || len < MAX_ERROR_DETAIL_LENGTH || typeof e.detail !== 'string') {
-        console.error(e.stack, e.detail);
+      const { stack, detail = '' } = e;
+      if (VERBOSE || typeof detail !== 'string' || detail.length < MAX_ERROR_DETAIL_LENGTH) {
+        console.error(stack, detail);
       } else {
-        const newDetail = `${(e.detail || '').slice(0, MAX_ERROR_DETAIL_LENGTH)}...
+        const newDetail = `${(detail || '').slice(0, MAX_ERROR_DETAIL_LENGTH)}...
           To see the full error, run happo with "VERBOSE=true")`;
-        console.error(e.stack, newDetail);
+        console.error(stack, newDetail);
       }
     });
     virtualConsole.sendTo(console, { omitJSDOMErrors: true });


### PR DESCRIPTION
It looks like jsdom will add this detail property to the error object
for regular exceptions:

  https://github.com/jsdom/jsdom/blob/3cb5ec40/lib/jsdom/living/helpers/runtime-script-errors.js#L63

However, for other types of errors, like XHR errors, this property does
not exist:

  https://github.com/jsdom/jsdom/blob/699ed6b7/lib/jsdom/living/xhr-utils.js#L49-L59

Unfortunately, this code was written in a way that causes it to error
out like this:

```
/path/to/repo/node_modules/happo.io/build/JSDOMDomProvider.js:20
      const len = e.detail.length;
                           ^
TypeError: Cannot read property 'length' of undefined
    at VirtualConsole.JSDOMDomProvider.virtualConsole.on.e (/path/to/repo/node_modules/happo.io/build/JSDOMDomProvider.js:20:28)
    at emitOne (events.js:116:13)
    at VirtualConsole.emit (events.js:211:7)
    at Object.dispatchError (/path/to/repo/node_modules/happo.io/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:63:53)
    at Request.client.on.err (/path/to/repo/node_modules/happo.io/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:674:20)
    at emitOne (events.js:121:20)
    at Request.emit (events.js:211:7)
    at Request.onRequestError (/path/to/repo/node_modules/happo.io/node_modules/request/request.js:881:8)
    at emitOne (events.js:116:13)
    at ClientRequest.emit (events.js:211:7)
```

I think we can refactor this in a way that will avoid this problem while
preserving the current behavior.