### PR TITLE
Throw if asset path cannot be resolved

### DIFF
--- a/src/prepareAssetsPackage.js
+++ b/src/prepareAssetsPackage.js
@@ -30,6 +30,11 @@ function makePackage({ paths, publicFolders }) {
 
     Object.keys(paths).forEach((assetPath) => {
       const resolvePath = paths[assetPath];
+
+      if (!resolvePath) {
+        throw new Error(`Unable to resolve asset path: ${assetPath}`);
+      }
+
       for (const publicFolder of publicFolders) {
         const folder = publicFolder.startsWith('/')
           ? publicFolder


### PR DESCRIPTION
I'm setting up happo for a project and am running into an error:

> entry name must be a non-empty string value

This is coming from the archiver package, and I think it can happen if
the `name` we pass to it is falsey. But it is hard for me to understand
where the problem might be in my setup, since this is all of the
information I have to work from.

In order to produce a more actionable error, I think we should throw
here.