### PR TITLE
Ignore empty <img> src attributes

### DIFF
--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -17,5 +17,5 @@ export default function findAssetPaths(doc = document) {
     });
   });
 
-  return imgPaths.filter((url) => !isAbsoluteUrl(url));
+  return imgPaths.filter((url) => !isAbsoluteUrl(url) && url.length);
 }

--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -17,5 +17,5 @@ export default function findAssetPaths(doc = document) {
     });
   });
 
-  return imgPaths.filter((url) => !isAbsoluteUrl(url) && url.length);
+  return imgPaths.filter((url) => !isAbsoluteUrl(url) && url.trim().length);
 }

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -27,7 +27,7 @@ it('finds path-relative urls', () => {
 });
 
 it('does not find empty images', () => {
-  html = '<img src="">';
+  html = '<img src=""><img src=" ">';
   expect(subject()).toEqual([]);
 });
 
@@ -40,23 +40,14 @@ it('finds multiple images', () => {
       <img src="/1x1.jpg">
     </div>
   `;
-  expect(subject()).toEqual([
-    '/1x1.jpg',
-    '/1x1.png',
-    '/circle.svg',
-    '/1x1.jpg',
-  ]);
+  expect(subject()).toEqual(['/1x1.jpg', '/1x1.png', '/circle.svg', '/1x1.jpg']);
 });
 
 it('finds assets in srcset attributes', () => {
   html = `
     <img src="/1x1.jpg" srcset="/1x1.jpg 197w, /1x1.png 393w, http://dns/1.png 600w">
   `;
-  expect(subject()).toEqual([
-    '/1x1.jpg',
-    '/1x1.jpg',
-    '/1x1.png',
-  ]);
+  expect(subject()).toEqual(['/1x1.jpg', '/1x1.jpg', '/1x1.png']);
 });
 
 it('handles invalid srcset attributes', () => {
@@ -84,10 +75,7 @@ it('handles srcset with commas', () => {
   html = `
     <img srcset="/f1,2,3.png 100w, /f1,3.png 200w">
   `;
-  expect(subject()).toEqual([
-    '/f1,2,3.png',
-    '/f1,3.png',
-  ]);
+  expect(subject()).toEqual(['/f1,2,3.png', '/f1,3.png']);
 });
 
 it('handles srcset with plenty of whitespace', () => {
@@ -97,8 +85,5 @@ it('handles srcset with plenty of whitespace', () => {
       /f1,3.png   200w"
     >
   `;
-  expect(subject()).toEqual([
-    '/1x1.png',
-    '/f1,3.png',
-  ]);
+  expect(subject()).toEqual(['/1x1.png', '/f1,3.png']);
 });

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -26,6 +26,11 @@ it('finds path-relative urls', () => {
   expect(subject()).toEqual(['circle.svg']);
 });
 
+it('does not find empty images', () => {
+  html = '<img src="">';
+  expect(subject()).toEqual([]);
+});
+
 it('finds multiple images', () => {
   html = `
     <div>

--- a/test/findCSSAssetPaths-test.js
+++ b/test/findCSSAssetPaths-test.js
@@ -35,6 +35,14 @@ it('does not find absolute urls', () => {
   expect(subject()).toEqual([]);
 });
 
+it('does not find empty urls', () => {
+  css = `
+    .body { background-image: url(); }
+    .foo { background-image: url(''); }
+  `;
+  expect(subject()).toEqual([]);
+});
+
 it('finds multiple images', () => {
   css = `
     .body { background-image: url(/1x1.jpg); }


### PR DESCRIPTION
When finding assets in the html snapshots, we were not properly handling
empty src attributes. This led to a cryptic error down the line:

  Error: entry name must be a non-empty string value

We can simply ignore empty src to fix this. While I was trying to
reproduce the issue, I wrote a test case for css asset finding as well,
and I decided to keep it around even if it didn't cause any trouble.