### PR TITLE
Replace srcset parsing regex with parse-srcset package

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jsdom": "^12.0.0",
     "jsonwebtoken": "^8.2.1",
     "mkdirp": "^0.5.1",
+    "parse-srcset": "^1.0.2",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "require-relative": "^0.8.7",

--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -1,6 +1,4 @@
-import matchAll from 'string.prototype.matchall';
-
-const SRCSET_ITEM = /([^\s]+)(\s+[0-9.]+[wx])?(,?\s*)/g;
+import parseSrcset from 'parse-srcset';
 
 function isAbsoluteUrl(src) {
   return src.startsWith('http') || src.startsWith('//');
@@ -12,8 +10,8 @@ export default function findAssetPaths(doc = document) {
   );
 
   doc.querySelectorAll('img[srcset]').forEach((img) => {
-    Array.from(matchAll(img.getAttribute('srcset') || '', SRCSET_ITEM)).forEach((match) => {
-      imgPaths.push(match[1]);
+    parseSrcset(img.getAttribute('srcset')).forEach((parsed) => {
+      imgPaths.push(parsed.url);
     });
   });
 

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -87,3 +87,10 @@ it('handles srcset with plenty of whitespace', () => {
   `;
   expect(subject()).toEqual(['/1x1.png', '/f1,3.png']);
 });
+
+it('handles srcset with multiple URLs with mixed descriptors', () => {
+  html = `
+    <img srcset="/1x1.png, /f1,3.png 200w">
+  `;
+  expect(subject()).toEqual(['/1x1.png', '/f1,3.png']);
+});


### PR DESCRIPTION
We found a bug where srcsets with multiple URLs and mixed descriptors
would be parsed incorrectly, causing the first URL without a descriptor
to include a trailing comma. Instead of relying on this regex, I found
what appears to be a good package for parsing this string according to
the spec.

This is a port of this PR: https://github.com/Galooshi/happo/pull/229