### PR TITLE
Find assets from inline styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jsdom": "^12.0.0",
     "jsonwebtoken": "^8.2.1",
     "mkdirp": "^0.5.1",
+    "parse-srcset": "^1.0.2",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "require-relative": "^0.8.7",

--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -1,6 +1,4 @@
-import matchAll from 'string.prototype.matchall';
-
-const SRCSET_ITEM = /([^\s]+)(\s+[0-9.]+[wx])?(,?\s*)/g;
+import parseSrcset from 'parse-srcset';
 
 function isAbsoluteUrl(src) {
   return src.startsWith('http') || src.startsWith('//');
@@ -12,8 +10,8 @@ export default function findAssetPaths(doc = document) {
   );
 
   doc.querySelectorAll('img[srcset]').forEach((img) => {
-    Array.from(matchAll(img.getAttribute('srcset') || '', SRCSET_ITEM)).forEach((match) => {
-      imgPaths.push(match[1]);
+    parseSrcset(img.getAttribute('srcset')).forEach((parsed) => {
+      imgPaths.push(parsed.url);
     });
   });
 

--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -1,5 +1,7 @@
 import parseSrcset from 'parse-srcset';
 
+import findCSSAssetPaths from './findCSSAssetPaths';
+
 function isAbsoluteUrl(src) {
   return src.startsWith('http') || src.startsWith('//');
 }
@@ -12,6 +14,12 @@ export default function findAssetPaths(doc = document) {
   doc.querySelectorAll('img[srcset]').forEach((img) => {
     parseSrcset(img.getAttribute('srcset')).forEach((parsed) => {
       imgPaths.push(parsed.url);
+    });
+  });
+
+  doc.querySelectorAll('[style]').forEach((el) => {
+    findCSSAssetPaths({ css: el.getAttribute('style') }).forEach((path) => {
+      imgPaths.push(path.resolvePath);
     });
   });
 

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -43,6 +43,19 @@ it('finds multiple images', () => {
   expect(subject()).toEqual(['/1x1.jpg', '/1x1.png', '/circle.svg', '/1x1.jpg']);
 });
 
+it('finds assets in inline styles', () => {
+  html = `
+    <div>
+      <div style="background-image: url(1.jpg);" />
+      <div style="background-image: url(./2.jpg);" />
+      <div style="background-image: url(/3.jpg);" />
+      <div style="background-image: url('/4.jpg');" />
+      <div style="background-image: url(http://dls/5.jpg);" />
+    </div>
+  `;
+  expect(subject()).toEqual(['1.jpg', './2.jpg', '/3.jpg', '/4.jpg']);
+});
+
 it('finds assets in srcset attributes', () => {
   html = `
     <img src="/1x1.jpg" srcset="/1x1.jpg 197w, /1x1.png 393w, http://dns/1.png 600w">

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -87,3 +87,10 @@ it('handles srcset with plenty of whitespace', () => {
   `;
   expect(subject()).toEqual(['/1x1.png', '/f1,3.png']);
 });
+
+it('handles srcset with multiple URLs with mixed descriptors', () => {
+  html = `
+    <img srcset="/1x1.png, /f1,3.png 200w">
+  `;
+  expect(subject()).toEqual(['/1x1.png', '/f1,3.png']);
+});


### PR DESCRIPTION
(Note: this contains 2 commits, the first is part of https://github.com/happo/happo.io/pull/101, and the second is the commit specifically for this PR)

Fixes #100

I have a snapshot that renders the following element:

```html
<div class="background_3l6wgj-o_O-large_usp5di" style="background-image: url(19674e0d6b42a252d31d6290dc406e1b.png);" role="img" aria-label="image"></div>
```

When happo takes a screenshot of this element, the image is missing.
When I view the snapshot source, I see the network request for this
image 404.

I believe that when the assets package is prepared, it is looking at
global CSS files, snap payloads, and things added to the public folders.

https://github.com/happo/happo.io/blob/b4ceb19bec/src/domRunner.js#L90-L94

The snapPayloads.assetPaths are added to the assets package here:

https://github.com/happo/happo.io/blob/b4ceb19bec/src/prepareAssetsPackage.js#L82-L86

So I believe the relevant part here is how snapPayloads.assetPaths is
generated. That happens in this loop:

https://github.com/happo/happo.io/blob/b4ceb19bec/src/processSnapsInBundle.js#L22-L28

Which calls this:

https://github.com/happo/happo.io/blob/b4ceb19bec/src/JSDOMDomProvider.js#L68-L70

Which then calls this:

https://github.com/happo/happo.io/blob/b4ceb19bec/src/browser/processor.js#L142-L174

I think the key line here is the call to findAssetPaths():

https://github.com/happo/happo.io/blob/b4ceb19bec/src/browser/processor.js#L167

Which is this function:

https://github.com/happo/happo.io/blob/b4ceb19bec/src/findAssetPaths.js#L9-L21

It looks like findAssetPaths will look for img src or img srcset, but
not other types of URLs, like in inline styles.

We can fix this by looking for elements with style attributes and
running those through findCSSAssetPaths.

It looks like findCSSAssetPaths takes a source option, which I wasn't
really sure what to do about or if it is needed here, so I left it out.
This function also gives an assetPath and a resolvePath, which I wasn't
really sure what the difference was and which one we want here. Looking
at the other test cases, it seems like resolvePath is more consistent
with what other things are doing.

