### PR TITLE
Add Node 10 and 12 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ addons:
 node_js:
   - "6"
   - "8"
+  - "10"
+  - "12"
 env:
   - WEBPACK_VERSION=4
   - WEBPACK_VERSION=3


### PR DESCRIPTION
10 is currently in LTS and 12 will start LTS in October. It seems
like a good idea to run CI on these versions.