### PR TITLE
Send `link` and `message` with `start-job` command

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -76,7 +76,12 @@ if [ "$CURRENT_SHA" = "$PREVIOUS_SHA" ] || [ -z "$PREVIOUS_SHA" ]; then
   exit 0;
 fi
 
-"$HAPPO_COMMAND" start-job "$PREVIOUS_SHA" "$CURRENT_SHA"
+COMMIT_SUBJECT="$(${HAPPO_GIT_COMMAND} show -s --format=%s)"
+COMMIT_AUTHOR="$(${HAPPO_GIT_COMMAND} show -s --format=%ae)"
+
+"$HAPPO_COMMAND" start-job "$PREVIOUS_SHA" "$CURRENT_SHA" \
+  --link "${CHANGE_URL}" \
+  --message "${COMMIT_SUBJECT}"
 
 run-happo "$CURRENT_SHA" true
 
@@ -95,9 +100,6 @@ if [ "$FIRST_RUN" = "true" ]; then
 fi
 
 # Compare reports from the two SHAs.
-COMMIT_SUBJECT="$(${HAPPO_GIT_COMMAND} show -s --format=%s)"
-COMMIT_AUTHOR="$(${HAPPO_GIT_COMMAND} show -s --format=%ae)"
-
 # `happo compare` exits with an exit code of 113 if there is a diff. To work with
 # the exit status, we need to temporarily turn off the fail-on-error behavior.
 set +e

--- a/src/commands/startJob.js
+++ b/src/commands/startJob.js
@@ -3,6 +3,7 @@ import makeRequest from '../makeRequest';
 export default function startJob(
   sha1,
   sha2,
+  { link, message },
   { apiKey, apiSecret, endpoint, project },
 ) {
   return makeRequest(
@@ -10,7 +11,7 @@ export default function startJob(
       url: `${endpoint}/api/jobs/${sha1}/${sha2}`,
       method: 'POST',
       json: true,
-      body: { project },
+      body: { project, link, message },
     },
     { apiKey, apiSecret },
   );

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -122,6 +122,10 @@ commander
     const result = await startJobCommand(
       sha1,
       sha2,
+      {
+        link: commander.link,
+        message: commander.message,
+      },
       await loadUserConfig(commander.config),
     );
     new Logger().info(result.id);

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -102,7 +102,7 @@ describe('when there is a report for PREVIOUS_SHA', () => {
   it('runs the right happo commands', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'start-job foo bar',
+      'start-job foo bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'has-report foo',
       'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
@@ -110,10 +110,10 @@ describe('when there is a report for PREVIOUS_SHA', () => {
     expect(getGitLog()).toEqual([
       'rev-parse foo',
       'rev-parse bar',
-      'checkout --force --quiet bar',
-      'show -s --format=%s',
       'show -s --format=%s',
       'show -s --format=%ae',
+      'checkout --force --quiet bar',
+      'show -s --format=%s',
       'checkout --force --quiet bar',
     ]);
   });
@@ -127,7 +127,7 @@ describe('when there is no report for PREVIOUS_SHA', () => {
   it('runs the right happo commands', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'start-job no-report bar',
+      'start-job no-report bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'has-report no-report',
       'run no-report --link http://foo.bar/ --message Commit message',
@@ -136,12 +136,12 @@ describe('when there is no report for PREVIOUS_SHA', () => {
     expect(getGitLog()).toEqual([
       'rev-parse no-report',
       'rev-parse bar',
+      'show -s --format=%s',
+      'show -s --format=%ae',
       'checkout --force --quiet bar',
       'show -s --format=%s',
       'checkout --force --quiet no-report',
       'show -s --format=%s',
-      'show -s --format=%s',
-      'show -s --format=%ae',
       'checkout --force --quiet bar',
     ]);
   });
@@ -155,7 +155,7 @@ describe('when the compare call fails', () => {
   it('fails the script', () => {
     expect(subject).toThrow();
     expect(getCliLog()).toEqual([
-      'start-job fail bar',
+      'start-job fail bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'has-report fail',
       'compare fail bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
@@ -163,10 +163,10 @@ describe('when the compare call fails', () => {
     expect(getGitLog()).toEqual([
       'rev-parse fail',
       'rev-parse bar',
-      'checkout --force --quiet bar',
-      'show -s --format=%s',
       'show -s --format=%s',
       'show -s --format=%ae',
+      'checkout --force --quiet bar',
+      'show -s --format=%s',
       'checkout --force --quiet bar',
     ]);
   });
@@ -180,7 +180,7 @@ describe('when happo.io is not installed for the PREVIOUS_SHA', () => {
   it('runs the right happo commands', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'start-job no-happo bar',
+      'start-job no-happo bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'has-report no-happo',
       'empty no-happo',
@@ -189,12 +189,12 @@ describe('when happo.io is not installed for the PREVIOUS_SHA', () => {
     expect(getGitLog()).toEqual([
       'rev-parse no-happo',
       'rev-parse bar',
+      'show -s --format=%s',
+      'show -s --format=%ae',
       'checkout --force --quiet bar',
       'show -s --format=%s',
       'checkout --force --quiet no-happo',
       'show -s --format=%s',
-      'show -s --format=%s',
-      'show -s --format=%ae',
       'checkout --force --quiet bar',
     ]);
   });


### PR DESCRIPTION
This will contextualize the job a little on the happo.io side, and it
will make sure that a github status is posted as soon as the job starts.