### PR TITLE
Retry failed start-job up to 3 times

### DIFF
--- a/src/commands/startJob.js
+++ b/src/commands/startJob.js
@@ -13,6 +13,6 @@ export default function startJob(
       json: true,
       body: { project, link, message },
     },
-    { apiKey, apiSecret },
+    { apiKey, apiSecret, maxTries: 3 },
   );
 }


### PR DESCRIPTION
I've been seeing the occasional error when running start-job that looks
like this:

> StatusCodeError: 503 - "upstream connect error or disconnect/reset
> before headers"

This has appeared about 3 times that I can tell over the past 2 days at
Airbnb. I think it is some intermittent problem, potentially in our
infrastructure, and we can probably just retry the API request and it
will probably just succeed. This will remove a small amount of pain for
our developers.