### PR TITLE
Allow remote browser target request to retry 6 times

### DIFF
--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -10,7 +10,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
       method: 'GET',
       json: true,
     },
-    { apiKey, apiSecret, maxTries: 3 },
+    { apiKey, apiSecret, maxTries: 6 },
   );
   if (status === 'done') {
     return result.map((i) => Object.assign({}, i, { snapRequestId: requestId }));


### PR DESCRIPTION
We occasionally see an error like:

> StatusCodeError: 500 - "An error occurred for browser-chrome: Timed
> out"

This is happening because when the load spikes, there aren't enough
workers to handle all of the traffic, and the current amount of waiting
and retrying is not enough to allow these jobs to succeed. I think we
can increase the reliability of happo CI jobs by retrying this request
more. Since we've added exponential backoff and jitter, this should be
relatively safe to do.