### PR TITLE
Strip query strings and hashes when finding assets

### DIFF
--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -1,6 +1,6 @@
 import parseSrcset from 'parse-srcset';
 
-import stripQueryString from './stripQueryString';
+import stripQueryStringAndHash from './stripQueryStringAndHash';
 import findCSSAssetPaths from './findCSSAssetPaths';
 
 function isAbsoluteUrl(src) {
@@ -26,5 +26,5 @@ export default function findAssetPaths(doc = document) {
 
   return imgPaths
     .filter((url) => !isAbsoluteUrl(url) && url.trim().length)
-    .map(stripQueryString);
+    .map(stripQueryStringAndHash);
 }

--- a/src/findAssetPaths.js
+++ b/src/findAssetPaths.js
@@ -1,5 +1,6 @@
 import parseSrcset from 'parse-srcset';
 
+import stripQueryString from './stripQueryString';
 import findCSSAssetPaths from './findCSSAssetPaths';
 
 function isAbsoluteUrl(src) {
@@ -23,5 +24,7 @@ export default function findAssetPaths(doc = document) {
     });
   });
 
-  return imgPaths.filter((url) => !isAbsoluteUrl(url) && url.trim().length);
+  return imgPaths
+    .filter((url) => !isAbsoluteUrl(url) && url.trim().length)
+    .map(stripQueryString);
 }

--- a/src/findCSSAssetPaths.js
+++ b/src/findCSSAssetPaths.js
@@ -2,7 +2,7 @@ import path from 'path';
 
 import matchAll from 'string.prototype.matchall';
 
-import stripQueryString from './stripQueryString';
+import stripQueryStringAndHash from './stripQueryStringAndHash';
 
 const URL_PATTERN = /url\(['"]?(\/?[^)"']+)['"]?\)/g;
 
@@ -19,7 +19,7 @@ export default function findCSSAssetPaths({ css, source }) {
   const paths = Array.from(matchAll(css, URL_PATTERN))
     .map((match) => match[1])
     .filter((url) => !/^http|\/\//.test(url))
-    .map(stripQueryString);
+    .map(stripQueryStringAndHash);
 
   if (!source) {
     return paths.map((p) => ({ assetPath: p, resolvePath: p }));

--- a/src/findCSSAssetPaths.js
+++ b/src/findCSSAssetPaths.js
@@ -2,6 +2,8 @@ import path from 'path';
 
 import matchAll from 'string.prototype.matchall';
 
+import stripQueryString from './stripQueryString';
+
 const URL_PATTERN = /url\(['"]?(\/?[^)"']+)['"]?\)/g;
 
 /**
@@ -16,16 +18,21 @@ const URL_PATTERN = /url\(['"]?(\/?[^)"']+)['"]?\)/g;
 export default function findCSSAssetPaths({ css, source }) {
   const paths = Array.from(matchAll(css, URL_PATTERN))
     .map((match) => match[1])
-    .filter((url) => !/^http|\/\//.test(url));
+    .filter((url) => !/^http|\/\//.test(url))
+    .map(stripQueryString);
+
   if (!source) {
     return paths.map((p) => ({ assetPath: p, resolvePath: p }));
   }
+
   const dir = path.dirname(source);
+
   return paths.map((url) => {
     if (url.startsWith('/')) {
       // absolute url
       return { assetPath: url, resolvePath: url };
     }
+
     const assetPath = path.join(dir, url);
     return { assetPath, resolvePath: url };
   });

--- a/src/stripQueryString.js
+++ b/src/stripQueryString.js
@@ -1,0 +1,3 @@
+export default function stripQueryString(url) {
+  return url.replace(/\?.*$/, '');
+}

--- a/src/stripQueryStringAndHash.js
+++ b/src/stripQueryStringAndHash.js
@@ -1,3 +1,3 @@
 export default function stripQueryString(url) {
-  return url.replace(/\?.*$/, '');
+  return url.replace(/[?#].*$/, '');
 }

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -26,6 +26,11 @@ it('finds path-relative urls', () => {
   expect(subject()).toEqual(['circle.svg']);
 });
 
+it('strips query strings', () => {
+  html = '<img src="circle.svg?pizza=yum">';
+  expect(subject()).toEqual(['circle.svg']);
+});
+
 it('does not find empty images', () => {
   html = '<img src=""><img src=" ">';
   expect(subject()).toEqual([]);
@@ -56,9 +61,29 @@ it('finds assets in inline styles', () => {
   expect(subject()).toEqual(['1.jpg', './2.jpg', '/3.jpg', '/4.jpg']);
 });
 
+it('strips query strings in inline styles', () => {
+  html = `
+    <div>
+      <div style="background-image: url(1.jpg?pizza=yum);" />
+      <div style="background-image: url(./2.jpg?pizza=yum);" />
+      <div style="background-image: url(/3.jpg?pizza=yum);" />
+      <div style="background-image: url('/4.jpg?pizza=yum');" />
+      <div style="background-image: url(http://dls/5.jpg?pizza=yum);" />
+    </div>
+  `;
+  expect(subject()).toEqual(['1.jpg', './2.jpg', '/3.jpg', '/4.jpg']);
+});
+
 it('finds assets in srcset attributes', () => {
   html = `
     <img src="/1x1.jpg" srcset="/1x1.jpg 197w, /1x1.png 393w, http://dns/1.png 600w">
+  `;
+  expect(subject()).toEqual(['/1x1.jpg', '/1x1.jpg', '/1x1.png']);
+});
+
+it('strips query strings in srcset attributes', () => {
+  html = `
+    <img src="/1x1.jpg" srcset="/1x1.jpg?pizza=yum 197w, /1x1.png?pizza=yum 393w, http://dns/1.png?pizza=yum 600w">
   `;
   expect(subject()).toEqual(['/1x1.jpg', '/1x1.jpg', '/1x1.png']);
 });

--- a/test/findAssetPaths-test.js
+++ b/test/findAssetPaths-test.js
@@ -31,6 +31,11 @@ it('strips query strings', () => {
   expect(subject()).toEqual(['circle.svg']);
 });
 
+it('strips hashes', () => {
+  html = '<img src="circle.svg#pizza">';
+  expect(subject()).toEqual(['circle.svg']);
+});
+
 it('does not find empty images', () => {
   html = '<img src=""><img src=" ">';
   expect(subject()).toEqual([]);
@@ -74,6 +79,19 @@ it('strips query strings in inline styles', () => {
   expect(subject()).toEqual(['1.jpg', './2.jpg', '/3.jpg', '/4.jpg']);
 });
 
+it('strips hashes in inline styles', () => {
+  html = `
+    <div>
+      <div style="background-image: url(1.jpg#pizza);" />
+      <div style="background-image: url(./2.jpg#pizza);" />
+      <div style="background-image: url(/3.jpg#pizza);" />
+      <div style="background-image: url('/4.jpg#pizza);" />
+      <div style="background-image: url(http://dls/5.jpg#pizza);" />
+    </div>
+  `;
+  expect(subject()).toEqual(['1.jpg', './2.jpg', '/3.jpg', '/4.jpg']);
+});
+
 it('finds assets in srcset attributes', () => {
   html = `
     <img src="/1x1.jpg" srcset="/1x1.jpg 197w, /1x1.png 393w, http://dns/1.png 600w">
@@ -84,6 +102,13 @@ it('finds assets in srcset attributes', () => {
 it('strips query strings in srcset attributes', () => {
   html = `
     <img src="/1x1.jpg" srcset="/1x1.jpg?pizza=yum 197w, /1x1.png?pizza=yum 393w, http://dns/1.png?pizza=yum 600w">
+  `;
+  expect(subject()).toEqual(['/1x1.jpg', '/1x1.jpg', '/1x1.png']);
+});
+
+it('strips hashes in srcset attributes', () => {
+  html = `
+    <img src="/1x1.jpg" srcset="/1x1.jpg#pizza 197w, /1x1.png#pizza 393w, http://dns/1.png#pizza 600w">
   `;
   expect(subject()).toEqual(['/1x1.jpg', '/1x1.jpg', '/1x1.png']);
 });

--- a/test/findCSSAssetPaths-test.js
+++ b/test/findCSSAssetPaths-test.js
@@ -22,6 +22,11 @@ it('strips query strings', () => {
   expect(subject()).toEqual([{ assetPath: '/1x1.png', resolvePath: '/1x1.png' }]);
 });
 
+it('strips hashes', () => {
+  css = '.body { background-image: url("/1x1.png#pizza");';
+  expect(subject()).toEqual([{ assetPath: '/1x1.png', resolvePath: '/1x1.png' }]);
+});
+
 it('finds svg', () => {
   css = '.body { background-image: url(circle.svg);';
   expect(subject()).toEqual([{ assetPath: 'circle.svg', resolvePath: 'circle.svg' }]);

--- a/test/findCSSAssetPaths-test.js
+++ b/test/findCSSAssetPaths-test.js
@@ -17,6 +17,11 @@ it('finds images', () => {
   expect(subject()).toEqual([{ assetPath: '/1x1.png', resolvePath: '/1x1.png' }]);
 });
 
+it('strips query strings', () => {
+  css = '.body { background-image: url("/1x1.png?pizza=yum");';
+  expect(subject()).toEqual([{ assetPath: '/1x1.png', resolvePath: '/1x1.png' }]);
+});
+
 it('finds svg', () => {
   css = '.body { background-image: url(circle.svg);';
   expect(subject()).toEqual([{ assetPath: 'circle.svg', resolvePath: 'circle.svg' }]);


### PR DESCRIPTION

Happo has some logic that looks for any local assets needed to render
the examples in a browser (e.g. images), and tries to bundle them up so
they can be available during screenshotting.

We've recently noticed a bug where some of our local images are failing
to load. When viewing source in the Happo UI, these images are 404ing,
and they do not exist in the assets zip file.

We noticed that these local images have some query strings added to
them. We believe that these query strings are causing these images to
not be bundled up with the other assets.

In this commit, I am hoping to make this better by stripping query
strings from the URLs. I started by trying to use node's URL built-in
parsing, but I found a couple of issues:

1. The `new URL()` API does not support relative URIs. There are some
   workarounds for this, like using a base of `relative:///`, but I was
   a bit worried about what unexpected consequences would arise from
   going this route. More information:
   https://github.com/nodejs/node/issues/12682
2. The `url.parse()` API is deprecated, and it gives you a URL object to
   work with. I wanted to essentially preserve the original format
   without adding any new information and I was a bit worried about
   getting that out of this object cleanly.

So in the end, I decided to write a simple regex for this.

My hunch is that this is an okay fix for now, but I imagine there might
be some situations where the query string is important for local images
and needs to be preserved in a better way so that all of the images are
correctly served. For example, imagine these two image URLs:

- ./foo.jpg?size=large
- ./foo.jpg?size=small

If these are used in an srcset, after this change, we will only bundle
up a single `./foo.jpg` image and that will be served for both.

I think the fix for this is a bit more involved (e.g. modifying the
image URLs so that the query strings are actually part of the filename,
or maybe storing them in a way that the server is able to pick the right
one when rendering examples for snapshotting), and it is unclear to me
if it actually matters at this time, so I'm calling YAGNI.

