### PR TITLE
Retry most requests 5 times

### DIFF
--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -10,7 +10,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
       method: 'GET',
       json: true,
     },
-    { apiKey, apiSecret, maxTries: 3 },
+    { apiKey, apiSecret, maxTries: 5 },
   );
   if (status === 'done') {
     return result.map((i) => Object.assign({}, i, { snapRequestId: requestId }));
@@ -74,7 +74,7 @@ export default class RemoteBrowserTarget {
             },
           },
         },
-        { apiKey, apiSecret, maxTries: 2 },
+        { apiKey, apiSecret, maxTries: 5 },
       );
     const promises = [];
     if (staticPackage) {

--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -37,7 +37,7 @@ export default async function compareReports(
           skipStatusPost,
         },
       },
-      { apiKey, apiSecret, maxTries: 2 },
+      { apiKey, apiSecret, maxTries: 5 },
     );
   const firstCompareResult = await makeCompareCall(
     typeof compareThreshold === 'number' || dryRun,

--- a/src/commands/startJob.js
+++ b/src/commands/startJob.js
@@ -13,6 +13,6 @@ export default function startJob(
       json: true,
       body: { project, link, message },
     },
-    { apiKey, apiSecret, maxTries: 3 },
+    { apiKey, apiSecret, maxTries: 5 },
   );
 }

--- a/src/uploadReport.js
+++ b/src/uploadReport.js
@@ -22,6 +22,6 @@ export default function uploadReport({
         project,
       },
     },
-    { apiKey, apiSecret, maxTries: 2 },
+    { apiKey, apiSecret, maxTries: 5 },
   );
 }


### PR DESCRIPTION
We are seeing some intermittent 404 errors when making various requests
in our Happo CI jobs:
```
StatusCodeError: 404 - "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
```

These 404s happen with a variety of requests, and the error message
appears to be generated by nginx, which Happo does not use. My suspicion
is that this is something else in our infrastructure that is being
flaky. While I investigate the root cause, I think making Happo a bit
more fault tolerant would help reduce some pain from our engineers when
stuff like this crops up.

Since we've added exponential backoff and jitter to the retry mechanism,
this should be relatively safe to do across the board.

Similar to #117 