### PR TITLE
Add `renderingOptions` to RemoteBrowserTarget

### DIFF
--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -22,7 +22,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
 const MIN_INTERNET_EXPLORER_WIDTH = 400;
 
 export default class RemoteBrowserTarget {
-  constructor(browserName, { viewport, chunks = 1, maxHeight, renderingOptions }) {
+  constructor(browserName, { viewport, chunks = 1, maxHeight, ...otherOptions }) {
     const viewportMatch = viewport.match(VIEWPORT_PATTERN);
     if (!viewportMatch) {
       throw new Error(
@@ -42,7 +42,7 @@ export default class RemoteBrowserTarget {
     this.browserName = browserName;
     this.viewport = viewport;
     this.maxHeight = maxHeight;
-    this.renderingOptions = renderingOptions;
+    this.otherOptions = otherOptions;
   }
 
   async execute({
@@ -66,7 +66,7 @@ export default class RemoteBrowserTarget {
             payload: {
               viewport: this.viewport,
               maxHeight: this.maxHeight,
-              renderingOptions: this.renderingOptions,
+              ...this.otherOptions,
               globalCSS,
               snapPayloads: slice,
               chunk,

--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -22,7 +22,7 @@ async function waitFor({ requestId, endpoint, apiKey, apiSecret }) {
 const MIN_INTERNET_EXPLORER_WIDTH = 400;
 
 export default class RemoteBrowserTarget {
-  constructor(browserName, { viewport, chunks = 1, maxHeight }) {
+  constructor(browserName, { viewport, chunks = 1, maxHeight, renderingOptions }) {
     const viewportMatch = viewport.match(VIEWPORT_PATTERN);
     if (!viewportMatch) {
       throw new Error(
@@ -42,6 +42,7 @@ export default class RemoteBrowserTarget {
     this.browserName = browserName;
     this.viewport = viewport;
     this.maxHeight = maxHeight;
+    this.renderingOptions = renderingOptions;
   }
 
   async execute({
@@ -65,6 +66,7 @@ export default class RemoteBrowserTarget {
             payload: {
               viewport: this.viewport,
               maxHeight: this.maxHeight,
+              renderingOptions: this.renderingOptions,
               globalCSS,
               snapPayloads: slice,
               chunk,

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -7,12 +7,15 @@ let viewport;
 let subject;
 let browserName;
 let chunks;
+let renderingOptions;
 
 beforeEach(() => {
   browserName = 'firefox';
   viewport = '400x300';
   chunks = 1;
-  subject = () => new RemoteBrowserTarget(browserName, { viewport, chunks });
+  renderingOptions = undefined;
+  subject = () =>
+    new RemoteBrowserTarget(browserName, { viewport, chunks, renderingOptions });
 });
 
 it('does not fail', () => {
@@ -48,6 +51,26 @@ describe('#execute', () => {
     );
   });
 
+  describe('with renderingOptions', () => {
+    beforeEach(() => {
+      renderingOptions = { foobar: true };
+    });
+
+    it('passes along the renderingOptions', async () => {
+      const target = subject();
+      await target.execute({
+        globalCSS: '* { color: red }',
+        snapPayloads: [{ html: '<div/>' }, { html: '<button/>' }, { html: '<li/>' }],
+        apiKey: 'foobar',
+        apiSecret: 'p@assword',
+        endpoint: 'http://localhost',
+      });
+      expect(makeRequest.mock.calls[0][0].body.payload.renderingOptions).toEqual({
+        foobar: true,
+      });
+    });
+  });
+
   describe('when chunks is equal to two', () => {
     beforeEach(() => {
       chunks = 2;
@@ -75,7 +98,9 @@ describe('#execute', () => {
         { html: '<div/>' },
         { html: '<button/>' },
       ]);
-      expect(makeRequest.mock.calls[2][0].body.payload.snapPayloads).toEqual([{ html: '<li/>' }]);
+      expect(makeRequest.mock.calls[2][0].body.payload.snapPayloads).toEqual([
+        { html: '<li/>' },
+      ]);
     });
 
     describe('with a staticPackage', () => {
@@ -97,7 +122,9 @@ describe('#execute', () => {
         // two POSTs and two GETs
         expect(makeRequest.mock.calls.length).toBe(4);
 
-        expect(makeRequest.mock.calls[0][0].body.payload.staticPackage).toEqual('foobar');
+        expect(makeRequest.mock.calls[0][0].body.payload.staticPackage).toEqual(
+          'foobar',
+        );
         expect(makeRequest.mock.calls[0][0].body.payload.chunk).toEqual({
           index: 0,
           total: 2,
@@ -153,7 +180,9 @@ describe('#execute', () => {
         // one POST and one GET
         expect(makeRequest.mock.calls.length).toBe(2);
 
-        expect(makeRequest.mock.calls[0][0].body.payload.staticPackage).toEqual('foobar');
+        expect(makeRequest.mock.calls[0][0].body.payload.staticPackage).toEqual(
+          'foobar',
+        );
       });
     });
   });

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -7,15 +7,15 @@ let viewport;
 let subject;
 let browserName;
 let chunks;
-let renderingOptions;
+let otherOptions;
 
 beforeEach(() => {
   browserName = 'firefox';
   viewport = '400x300';
   chunks = 1;
-  renderingOptions = undefined;
+  otherOptions = {};
   subject = () =>
-    new RemoteBrowserTarget(browserName, { viewport, chunks, renderingOptions });
+    new RemoteBrowserTarget(browserName, { viewport, chunks, ...otherOptions });
 });
 
 it('does not fail', () => {
@@ -51,12 +51,12 @@ describe('#execute', () => {
     );
   });
 
-  describe('with renderingOptions', () => {
+  describe('with other options', () => {
     beforeEach(() => {
-      renderingOptions = { foobar: true };
+      otherOptions = { foobar: true };
     });
 
-    it('passes along the renderingOptions', async () => {
+    it('passes along the other options', async () => {
       const target = subject();
       await target.execute({
         globalCSS: '* { color: red }',
@@ -65,9 +65,7 @@ describe('#execute', () => {
         apiSecret: 'p@assword',
         endpoint: 'http://localhost',
       });
-      expect(makeRequest.mock.calls[0][0].body.payload.renderingOptions).toEqual({
-        foobar: true,
-      });
+      expect(makeRequest.mock.calls[0][0].body.payload.foobar).toBe(true);
     });
   });
 


### PR DESCRIPTION
The rendering options are used by happo workers to control certain type
of behavior. Right now the only supported option (currently under
development) is `prefersReducedMotion` (chrome only) but more might
come.