### PR TITLE
Skip git checkout when run-happo is in quick mode

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -50,7 +50,10 @@ run-happo() {
   SHA=$1
   QUICK=$2
 
-  ${HAPPO_GIT_COMMAND} checkout --force --quiet "$SHA"
+  if [ "$QUICK" = "false" ]; then
+    ${HAPPO_GIT_COMMAND} checkout --force --quiet "$SHA"
+  fi
+
   COMMIT_SUBJECT="$(${HAPPO_GIT_COMMAND} show -s --format=%s)"
 
   if [ "$QUICK" = "false" ]; then

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -92,7 +92,6 @@ describe('when CURRENT_SHA and PREVIOUS_SHA is the same', () => {
     expect(getGitLog()).toEqual([
       'rev-parse bar',
       'rev-parse bar',
-      'checkout --force --quiet bar',
       'show -s --format=%s',
     ]);
   });
@@ -112,7 +111,6 @@ describe('when there is a report for PREVIOUS_SHA', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'checkout --force --quiet bar',
       'show -s --format=%s',
     ]);
   });
@@ -137,7 +135,6 @@ describe('when there is no report for PREVIOUS_SHA', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'checkout --force --quiet bar',
       'show -s --format=%s',
       'checkout --force --quiet no-report',
       'show -s --format=%s',
@@ -164,7 +161,6 @@ describe('when the compare call fails', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'checkout --force --quiet bar',
       'show -s --format=%s',
     ]);
   });
@@ -189,7 +185,6 @@ describe('when happo.io is not installed for the PREVIOUS_SHA', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'checkout --force --quiet bar',
       'show -s --format=%s',
       'checkout --force --quiet no-happo',
       'show -s --format=%s',


### PR DESCRIPTION
The first time that Happo runs in CI, it currently runs `git checkout`
to check out the SHA. However, git should already be on that SHA since
it is the first run.

At Airbnb, I noticed that this step can take ~10 seconds, so skipping
over it when it is unnecessary should give us a little speed boost. It
is unclear to me exactly why this would take so long, so maybe all of
the time will just move over to the next git operation, but this seems
like a reasonable thing to do regardless.