### PR TITLE
Be smarter about checking out and npm installing

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -48,21 +48,20 @@ run-install() {
 
 run-happo() {
   SHA=$1
-  QUICK=$2
+  HEAD_SHA=$(${HAPPO_GIT_COMMAND} rev-parse HEAD)
+  RUN_HAPPO_CHECK="false"
 
-  if [ "$QUICK" = "false" ]; then
+  if [ "$HEAD_SHA" != "$SHA" ]; then
+    RUN_HAPPO_CHECK="true"
     ${HAPPO_GIT_COMMAND} checkout --force --quiet "$SHA"
+    # Install dependencies (again, since we're in a different place in git
+    # history)
+    run-install
   fi
 
   COMMIT_SUBJECT="$(${HAPPO_GIT_COMMAND} show -s --format=%s)"
 
-  if [ "$QUICK" = "false" ]; then
-    # Install dependencies (again, since we're potentially in a different place in
-    # git history)
-    run-install
-  fi
-
-  if [ "$QUICK" = "true" ] || eval "$CHECK_FOR_HAPPO"; then
+  if [ "$RUN_HAPPO_CHECK" = "false" ] || eval "$CHECK_FOR_HAPPO"; then
     "$HAPPO_COMMAND" run "$SHA" \
     --link "${CHANGE_URL}" \
     --message "${COMMIT_SUBJECT}"
@@ -75,7 +74,7 @@ run-happo() {
 if [ "$CURRENT_SHA" = "$PREVIOUS_SHA" ] || [ -z "$PREVIOUS_SHA" ]; then
   echo "We're not on a branch, so there's nothing to compare against."
   echo "Running a single happo run on ${CURRENT_SHA}"
-  run-happo "$CURRENT_SHA" true
+  run-happo "$CURRENT_SHA"
   exit 0;
 fi
 
@@ -86,14 +85,14 @@ COMMIT_AUTHOR="$(${HAPPO_GIT_COMMAND} show -s --format=%ae)"
   --link "${CHANGE_URL}" \
   --message "${COMMIT_SUBJECT}"
 
-run-happo "$CURRENT_SHA" true
+run-happo "$CURRENT_SHA"
 
 # Check if we need to generate a baseline. In some cases, the baseline is
 # already there (some other PR uploaded it), and we can just use the existing
 # one.
 if ! "$HAPPO_COMMAND" has-report "$PREVIOUS_SHA"; then
   echo "No previous report found for ${PREVIOUS_SHA}. Generating one..."
-  run-happo "$PREVIOUS_SHA" false
+  run-happo "$PREVIOUS_SHA"
 
   # Restore git and node_modules to their original state so that we can run
   # `happo compare` on CURRENT_SHA instead of PREVIOUS_SHA.

--- a/test/git-mock.js
+++ b/test/git-mock.js
@@ -10,8 +10,13 @@ const tmpFile = path.join(os.tmpdir(), 'git-mock-log.txt');
 fs.writeFileSync(tmpFile, `${process.argv.slice(2).join(' ')}\n`, { flag: 'a' });
 
 if (cmd === 'rev-parse') {
-  // simply echo the sha/identifier
-  console.log(process.argv[3]);
+  const rev = process.argv[3];
+  if (rev === 'HEAD') {
+    console.log('bar');
+  } else {
+    // simply echo the sha/identifier
+    console.log(rev);
+  }
 } else if (cmd === 'checkout') {
   // no-op the checkout command
   process.exit(0);

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -92,6 +92,7 @@ describe('when CURRENT_SHA and PREVIOUS_SHA is the same', () => {
     expect(getGitLog()).toEqual([
       'rev-parse bar',
       'rev-parse bar',
+      'rev-parse HEAD',
       'show -s --format=%s',
     ]);
   });
@@ -111,6 +112,7 @@ describe('when there is a report for PREVIOUS_SHA', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
+      'rev-parse HEAD',
       'show -s --format=%s',
     ]);
   });
@@ -135,7 +137,9 @@ describe('when there is no report for PREVIOUS_SHA', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
+      'rev-parse HEAD',
       'show -s --format=%s',
+      'rev-parse HEAD',
       'checkout --force --quiet no-report',
       'show -s --format=%s',
       'checkout --force --quiet bar',
@@ -161,6 +165,7 @@ describe('when the compare call fails', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
+      'rev-parse HEAD',
       'show -s --format=%s',
     ]);
   });
@@ -185,7 +190,9 @@ describe('when happo.io is not installed for the PREVIOUS_SHA', () => {
       'rev-parse bar',
       'show -s --format=%s',
       'show -s --format=%ae',
+      'rev-parse HEAD',
       'show -s --format=%s',
+      'rev-parse HEAD',
       'checkout --force --quiet no-happo',
       'show -s --format=%s',
       'checkout --force --quiet bar',


### PR DESCRIPTION
A recent commit (7780feb) made happo-ci skip doing a git checkout for
the current sha. This is good, as it makes things faster (a git checkout
can take some time in a large repo). But it made me aware of a flaw in
the logic around "QUICK". In most cases, CURRENT_SHA will be the same as
HEAD. But in some cases (as is the case when CI runs on a constructed
merge commit), CURRENT_SHA might actually be different from HEAD. In
this case we actually want to perform the git checkout.

By adjusting the "QUICK" logic to instead rev-parse the HEAD to see what
sha we're currently on and compare with the sha in question, we can keep
the speed-up from 7780feb yet still do the right thing when CURRENT_SHA
is not HEAD.