### PR TITLE
Fix incorrect timing numbers

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -12,6 +12,7 @@ function withColorSupport(wrappedFunc) {
 }
 const red = withColorSupport((str) => `\x1b[31m${str}\x1b[0m`);
 const green = withColorSupport((str) => `\x1b[32m${str}\x1b[0m`);
+const dim = withColorSupport((str) => `\x1b[90m${str}\x1b[0m`);
 const underline = withColorSupport((str) => `\x1b[36m\x1b[4m${str}\x1b[0m`);
 
 export default class Logger {
@@ -38,14 +39,16 @@ export default class Logger {
     this.print('\n');
   }
 
-  start(msg) {
-    this.startTime = performance.now();
-    this.print(`${msg} `);
+  start(msg, { startTime } = {}) {
+    this.startTime = startTime || performance.now();
+    if (msg) {
+      this.print(`${msg} `);
+    }
   }
 
   printDuration() {
     if (this.startTime) {
-      this.print(` (${(performance.now() - this.startTime).toFixed(1)}ms)`);
+      this.print(dim(` (${(performance.now() - this.startTime).toFixed(1)}ms)`));
     }
   }
 

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import readline from 'readline';
+import { performance } from 'perf_hooks';
 
 import JSDOMDomProvider from './JSDOMDomProvider';
 import Logger from './Logger';
@@ -155,6 +156,8 @@ async function generateScreenshots(
     const results = await Promise.all(
       targetNames.map(async (name) => {
         let result;
+
+        const startTime = performance.now();
         if (prerender) {
           result = await executeTargetWithPrerender({
             name,
@@ -178,7 +181,7 @@ async function generateScreenshots(
             endpoint,
           });
         }
-        logger.start(`  - ${name}`);
+        logger.start(`  - ${name}`, { startTime });
         logger.success();
         return { name, result };
       }),

--- a/src/pageRunner.js
+++ b/src/pageRunner.js
@@ -1,3 +1,5 @@
+import { performance } from 'perf_hooks';
+
 import Logger from './Logger';
 import constructReport from './constructReport';
 
@@ -11,22 +13,25 @@ export default async function pagesRunner({
   const logger = new Logger();
   try {
     logger.info('Preparing job for remote execution...');
+    const outerStartTime = performance.now();
     const targetNames = Object.keys(targets);
     const tl = targetNames.length;
     logger.info(`Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
     const results = await Promise.all(
       targetNames.map(async (name) => {
+        const startTime = performance.now();
         const result = await targets[name].execute({
           pages,
           apiKey,
           apiSecret,
           endpoint,
         });
-        logger.start(`  - ${name}`);
+        logger.start(`  - ${name}`, { startTime });
         logger.success();
         return { name, result };
       }),
     );
+    logger.start(undefined, { startTime: outerStartTime });
     logger.success();
     return constructReport(results);
   } catch (e) {


### PR DESCRIPTION
This is a little hacky, ideally we'd detach timing numbers from the
logger. It fixes logs like these:

- chrome-small ✅ (0.1ms)
- chrome-large ✅ (0.1ms)

Instead, you'll see real timing numbers:

- chrome-small ✅ (1234.7ms)
- chrome-large ✅ (7613.2ms)