### PR TITLE
Add integration test to verify build errors are handled

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 build
+test/integrations/examples/*-error-*

--- a/test/integrations/error-test.js
+++ b/test/integrations/error-test.js
@@ -33,6 +33,29 @@ it('throws on errors', async () => {
   expect(false).toBe(true);
 });
 
+describe('with a syntax error', () => {
+  beforeEach(() => {
+    config.include = 'test/integrations/examples/*-error-syntax-happo.js*';
+    config.type = 'react';
+  });
+
+  it('throws an error', async () => {
+    try {
+      await subject();
+    } catch (e) {
+      expect(e.message).toMatch(
+        /Module build failed/,
+      );
+      return;
+    }
+
+    console.log(config.targets.firefox.snapPayloads);
+
+    // If we end up here, something is wrong
+    expect(false).toBe(true);
+  });
+});
+
 describe('with a misconfigured file', () => {
   beforeEach(() => {
     config.include = 'test/integrations/examples/*-error-misconfigured-happo.js*';

--- a/test/integrations/examples/Foo-error-syntax-happo.js
+++ b/test/integrations/examples/Foo-error-syntax-happo.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () <div>Hello default!</div>;


### PR DESCRIPTION
We're tracking down a strange bug where the happo run fails silently
with an uncaught build error logged to the console. This is an attempt
to recreate.