### PR TITLE
Use new YIQ colorDelta for deep compare 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1130,17 +1130,22 @@ module.exports = {
 };
 ```
 
-## `compareThreshold`
+## `compareThreshold` (experimental)
 
 By default, a shallow comparison is made when `happo compare` is called. If two
 images have one or more different pixels, it will be reported as a diff --
 even if the diff is very small. If you set a `compareThreshold`, a deep
-comparison will be performed instead, where individual pixels are inspected. A
-[euclidean
-distance](https://en.m.wikipedia.org/wiki/Color_difference#Euclidean) is
-computed for every diffing pixel. If all diffing pixels have a euclidean
-distance smaller than the `compareThreshold`, the diff is considered okay and
-the two images will be considered visually equal.
+comparison will be performed instead, where individual pixels are inspected.
+
+
+A color distance is computed for every diffing pixel. If all diffing pixels have
+a color distance smaller than the `compareThreshold`, the diff is considered
+okay and the two images will be considered visually equal.
+
+The difference is calculated according to the paper ["Measuring perceived color
+difference using YIQ NTSC transmission color space in mobile applications" by
+Y. Kotsarenko and F.
+Ramos](http://www.progmat.uaem.mx:8080/artVol2Num2/Articulo3Vol2Num2.pdf).
 
 A **word of warning** here. If the threshold is too high, you risk hiding diffs
 that you wouldn't want to be hidden. Be careful when you start using this
@@ -1148,14 +1153,14 @@ option.
 
 ```js
 module.exports = {
-  compareThreshold: 0.05,
+  compareThreshold: 0.005,
 };
 ```
 
-To help find the right euclidean distance value to use, you can make dry-run
-comparisons. Find one or a few comparisons (via https://happo.io/dashboard) and
-run `happo compare <sha1> <sha2> --dry-run` on the shas and look at what's
-being logged to figure out what threshold value you want to use.
+To help find the right value to use, you can make dry-run comparisons. Find one
+or a few comparisons (via https://happo.io/dashboard) and run `happo compare
+<sha1> <sha2> --dry-run` on the SHAs and look at what's being logged to figure
+out what threshold value you want to use.
 
 ## `asyncTimeout`
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jimp": "^0.8.0",
     "jsdom": "^15.2.1",
     "jsonwebtoken": "^8.2.1",
+    "lcs-image-diff": "^2.0.0",
     "mkdirp": "^0.5.1",
     "parse-srcset": "^1.0.2",
     "request": "^2.85.0",

--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -78,7 +78,7 @@ export default async function compareReports(
         log(
           `✗ ${after.component} - ${after.variant} - ${
             after.target
-          } - found diff pixel with euclidean distance ${firstDiffDistance} which is larger than threshold`,
+          } - found diff pixel with a color delta of ${firstDiffDistance} which is larger than threshold`,
         );
       }
     }),

--- a/src/compareSnapshots.js
+++ b/src/compareSnapshots.js
@@ -1,6 +1,5 @@
 import Jimp from 'jimp';
-
-const MAX_EUCLIDEAN_DISTANCE = Math.sqrt(255 ** 2 * 4);
+import colorDelta from 'lcs-image-diff/src/colorDelta';
 
 function makeAbsolute(url, endpoint) {
   if (url.startsWith('http')) {
@@ -9,20 +8,11 @@ function makeAbsolute(url, endpoint) {
   return `${endpoint}${url}`;
 }
 
-function euclideanDistance(rgba1, rgba2) {
-  return Math.sqrt(
-    (rgba1[0] - rgba2[0]) ** 2 +
-      (rgba1[1] - rgba2[1]) ** 2 +
-      (rgba1[2] - rgba2[2]) ** 2 +
-      (rgba1[3] - rgba2[3]) ** 2,
-  );
-}
-
 function imageDiff({ bitmap1, bitmap2, compareThreshold }) {
   const len = bitmap1.width * bitmap1.height * 4;
   for (let i = 0; i < len; i += 4) {
     const distance =
-      euclideanDistance(
+      colorDelta(
         [
           bitmap1.data[i],
           bitmap1.data[i + 1],
@@ -35,7 +25,7 @@ function imageDiff({ bitmap1, bitmap2, compareThreshold }) {
           bitmap2.data[i + 2],
           bitmap2.data[i + 3],
         ],
-      ) / MAX_EUCLIDEAN_DISTANCE;
+      );
     if (distance > compareThreshold) {
       return distance;
     }

--- a/test/commands/compareReports-test.js
+++ b/test/commands/compareReports-test.js
@@ -45,7 +45,7 @@ it('succeeds', async () => {
   expect(result.resolved).toEqual([]);
   expect(log.mock.calls).toEqual([
     ['Found 1 diffs to deep-compare using threshold 0.00005'],
-    ['✗ Foo - bar - chrome - found diff pixel with euclidean distance 0.003396178054056622 which is larger than threshold'],
+    ['✗ Foo - bar - chrome - found diff pixel with a color delta of 0.00005739599717234143 which is larger than threshold'],
     ['Mocked summary'],
   ]);
 });

--- a/test/compareSnapshots-test.js
+++ b/test/compareSnapshots-test.js
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 it('returns the diff value when diff is above threshold between images', async () => {
-  expect(await subject()).toEqual(0.20605968086932788);
+  expect(await subject()).toEqual(0.20549884392955664);
 });
 
 describe('when images are completely different', () => {
@@ -48,7 +48,7 @@ describe('when images are completely different', () => {
   });
 
   it('returns the diff value', async () => {
-    expect(await subject()).toEqual(0.8660254037844387);
+    expect(await subject()).toEqual(0.9330436790328738);
   });
 });
 
@@ -101,11 +101,11 @@ describe('with a minor diff', () => {
 
   describe('when the threshold changes', () => {
     beforeEach(() => {
-      compareThreshold = 0.02;
+      compareThreshold = 0.0002;
     });
 
     it('returns the diff value', async () => {
-      expect(await subject()).toEqual(0.020377068324339734);
+      expect(await subject()).toEqual(0.00022958398868936736);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,6 +3409,11 @@ ignore@^3.3.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
+imagetracerjs@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/imagetracerjs/-/imagetracerjs-1.2.5.tgz#bff3792706cbbf2dd57131f4b50d38221efa1d6b"
+  integrity sha512-EQkBqvpW+36hx8ANxQ4RqqGxl6USmM3N8IiVw33lQlRW/P4eBpBxUJX36uzoyLfPc/0sBnX0ktyan/gCbJhtcw==
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -4382,6 +4387,13 @@ lcid@^1.0.0:
   integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
+
+lcs-image-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcs-image-diff/-/lcs-image-diff-2.0.0.tgz#dea20c1fee65c281df731bf3f7700599638d70ea"
+  integrity sha512-K5QmW+Ae9kwSF/4fimSoEurxeFPDJl8iBAS7qW5WhQBWNWVDG4VKY0Xm9aOUPB1/XuEX78tUwXBZRd2FeYmuPA==
+  dependencies:
+    imagetracerjs "^1.2.5"
 
 left-pad@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION

This should better align the compareThreshold option with human
perception.

From https://github.com/happo/lcs-image-diff/pull/6

***

Our first iteration of measuring the difference of two colors used a
basic euclidean distance. However, this is not very well aligned
with how human vision works, so it produces disappointing results when
applied to real world diffs.

Looking for a better option, I found mapbox's pixelmatch package, which
describes itself as:

> The smallest, simplest and fastest JavaScript pixel-level image
> comparison library, originally created to compare screenshots in
> tests.

This sounds perfect for this application.

The pixelmatch package has functions that take two entire images, and
does a lot more than we actually need here, so instead of pulling it in
as a dependency, I decided to copy and modify the relevant code to
better fit our use-case.

This is a perceived color difference using YIQ NTSC transmission color
space. More information can be found in this paper:

  http://www.progmat.uaem.mx:8080/artVol2Num2/Articulo3Vol2Num2.pdf

pixelmatch has an anti-aliasing detection feature which will exclude
anti-aliased pixels as "different" that I didn't include here, but that
might be worth investigating down the road.

One aspect of this change that I'm not entirely sure of is pixelmatch
has a threshold option that it uses to ignore changes lower than a
specified delta percentage. This threshold option is squared against
the max YIQ difference. Since we are returning a normalized value
between 0 and 1 here, it isn't entirely clear to me if we should be
dividing the difference by the max difference, taking a square root
somewhere, or square the threshold option when using deep compare (in a
different project).

Another aspect that I'm not entirely sure about is that this algorithm
will blend semi-transparent colors with white, which means that white
and fully transparent are reported as the same thing.

