### PR TITLE
Improve master branch runs for happo-ci-travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,18 @@ language: node_js
 script:
   - npm run happo-ci-travis
 ```
+The `happo-ci-travis` script assumes that your PRs are based off of the master
+branch. If you're using a different default branch, you can set the
+`BASE_BRANCH` environment variable.
+
+```json
+{
+  "scripts": {
+    "happo": "happo",
+    "happo-ci-travis": "BASE_BRANCH=\"dev\" happo-ci-travis"
+  }
+}
+```
 
 ## `happo-ci-circleci`
 

--- a/bin/happo-ci-circleci
+++ b/bin/happo-ci-circleci
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 BASE_BRANCH=${BASE_BRANCH:-"origin/master"}
-echo "Using ${BASE_BRANCH} as the base branch"
+echo "Using ${BASE_BRANCH} as the default branch (change this with the BASE_BRANCH environment variable)"
 PREVIOUS_SHA=$(git merge-base "${BASE_BRANCH}" "${CIRCLE_SHA1}")
 
 export PREVIOUS_SHA

--- a/bin/happo-ci-travis
+++ b/bin/happo-ci-travis
@@ -3,6 +3,9 @@
 # Make the whole script fail on errors
 set -eou pipefail
 
+BASE_BRANCH=${BASE_BRANCH:-"master"}
+echo "Using ${BASE_BRANCH} as the default branch (change this with the BASE_BRANCH environment variable)"
+
 if [ ! -z "${TRAVIS_COMMIT_RANGE:-}" ]; then
   # The PREVIOUS_SHA will be equal to the commit that the PR is based on (which
   # is usually some commit on the master branch), or the commit that the last
@@ -12,6 +15,10 @@ if [ ! -z "${TRAVIS_COMMIT_RANGE:-}" ]; then
   if ! git cat-file -e "$PREVIOUS_SHA"^{commit}; then
     # When force-pushing, the base commit in the commit range might not be a
     # real commit
+    PREVIOUS_SHA=""
+  elif [ "$TRAVIS_EVENT_TYPE" = "push" ] && [ "$TRAVIS_BRANCH" = "$BASE_BRANCH" ]; then
+    # This is a build on the default/base branch. We'll reset PREVIOUS_SHA to
+    # prevent making any comparison.
     PREVIOUS_SHA=""
   fi
 else


### PR DESCRIPTION
For a default branch build, the happo-ci-travis script would run a
comparison between the current commit and the commit that travis last
knew about (that it had built). This led to failing builds for people
on some master/default branch builds because there would be a red happo
status (needs review). We can make this better by detecting when there
is a master/default branch build and only run a single report for that
commit.

Unfortunately, there's no way in Travis to know what the default branch,
so we'll have to default on `master` and then let people pass in a
different base branch using BASE_BRANCH if master isn't the one. This is
similar to what the happo-ci-circleci script does (although it depends
on it even more by looking up the PREVIOUS_SHA using a git-rev-parse).