### PR TITLE
Target node 8 in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": ["6"]
+        "node": ["8"]
       }
     }]
   ],


### PR DESCRIPTION
We haven't supported Node 6 in a while.