### PR TITLE
Throw instead of exiting on unhandledRejection

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,7 @@ function printErrorIter(error, logger) {
 
 process.on('unhandledRejection', (error) => {
   printErrorIter(error, new Logger());
-  process.exit(1);
+  throw error;
 });
 
 executeCli(process.argv);


### PR DESCRIPTION
We're trying to track down an issue where a build with a lot of diffs
(~2000) being deep-compared is leading to the process exiting (1)
without having had time to complete all the stdout/stderr printing.
Since writing to stdout/err is asynchronous in nature, we believe that
the call to process.exit in our unhandledRejections handler is masking
the error being logged right before the exit. By instead throwing an
error we get the same behavior (exit 1) but we allow node to finish up
what it needs to do first.