### PR TITLE
Log less in compareReports

### DIFF
--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -74,22 +74,23 @@ export default async function compareReports(
           log(
             `✓ ${after.component} - ${after.variant} - ${
               after.target
-            } - diff is below threshold, auto-ignoring`,
+            } - diff below threshold, auto-ignoring`,
           );
           if (!dryRun) {
             await ignore({ before, after, apiKey, apiSecret, endpoint });
           }
           resolved.push([before, after]);
-        } else {
-          log(
-            `✗ ${after.component} - ${after.variant} - ${
-              after.target
-            } - diff of ${firstDiffDistance} is larger than threshold ${compareThreshold}, not auto-ignoring`,
-          );
         }
       }),
     );
   }
+
+  const totalDiffsCount = firstCompareResult.diffs.length;
+  const autoIgnoredDiffsCount = resolved.length;
+
+  log(
+    `${autoIgnoredDiffsCount} out of ${totalDiffsCount} were below threshold and auto-ignored`,
+  );
 
   // Make second compare call to finalize the deep compare. The second call will
   // cause a status to be posted to the PR (if applicable). Any ignored diffs

--- a/test/commands/compareReports-test.js
+++ b/test/commands/compareReports-test.js
@@ -51,9 +51,7 @@ it('succeeds', async () => {
   expect(result.resolved).toEqual([]);
   expect(log.mock.calls).toEqual([
     ['Found 1 diffs to deep-compare using threshold 0.00005'],
-    [
-      '✗ Foo - bar - chrome - diff of 0.00005739599717234143 is larger than threshold 0.00005, not auto-ignoring',
-    ],
+    ['0 out of 1 were below threshold and auto-ignored'],
     ['Mocked summary'],
   ]);
 });
@@ -82,7 +80,8 @@ describe('when threshold is larger than the diff', () => {
 
     expect(log.mock.calls).toEqual([
       ['Found 1 diffs to deep-compare using threshold 0.1'],
-      ['✓ Foo - bar - chrome - diff is below threshold, auto-ignoring'],
+      ['✓ Foo - bar - chrome - diff below threshold, auto-ignoring'],
+      ['1 out of 1 were below threshold and auto-ignored'],
       ['Mocked summary'],
     ]);
 
@@ -102,7 +101,8 @@ describe('when threshold is larger than the diff', () => {
       expect(log.mock.calls).toEqual([
         ['Found 1 diffs to deep-compare using threshold 0.1'],
         ['Running in --dry-run mode -- no destructive commands will be issued'],
-        ['✓ Foo - bar - chrome - diff is below threshold, auto-ignoring'],
+        ['✓ Foo - bar - chrome - diff below threshold, auto-ignoring'],
+        ['1 out of 1 were below threshold and auto-ignored'],
         ['Mocked summary'],
       ]);
 


### PR DESCRIPTION
We are running into an issue where our CI job fails when the number
of diffs to compare is really long. The error messages are either
never output, or confusing ("echo: write error: Resource temporarily
unavailable") so we don't have any strong leads on what exactly
could be causing it, and we have yet been able to reproduce it
locally.

One theory we have is that we are logging too much too quickly in
node which is causing the command to fail. A lot of this logging is
pretty unnecessary anyway so we are hoping to narrow down the
problem by logging less.