### PR TITLE
Add support for async reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,17 @@ INSTALL_CMD="lerna bootstrap" npm run happo-ci-travis
 In this example, the `lerna bootstrap` command will be invoked before running
 `happo run` on each commit, instead of `yarn install`/`npm install`.
 
+By default, all `happo-ci` commands will wait for screenshots to be done before
+finishing. If you have [authorized your Happo account to post statuses back to
+PRs/commits](#posting-statuses-back-to-prscommits), you can set a
+`HAPPO_IS_ASYNC=true` environment variable to instruct Happo to finish the CI
+task as soon as possible and then instead wait for the status to come back via
+happo.io.
+
+```bash
+HAPPO_IS_ASYNC=true npm run happo-ci-circleci
+```
+
 ## `happo-ci-travis`
 
 This script knows about the Travis build environment, assuming a PR based

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "5.1.5",
+  "version": "5.2.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "5.2.0-rc.2",
+  "version": "5.2.0-rc.3",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "5.2.0-rc.1",
+  "version": "5.2.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -20,7 +20,7 @@ export default async function compareReports(
   sha1,
   sha2,
   { apiKey, apiSecret, endpoint, project, compareThreshold },
-  { link, message, author, dryRun },
+  { link, message, author, dryRun, isAsync },
   log = console.log,
   maxTries = 5,
 ) {
@@ -36,6 +36,7 @@ export default async function compareReports(
           author,
           project,
           skipStatusPost,
+          isAsync,
         },
       },
       { apiKey, apiSecret, maxTries },
@@ -43,7 +44,7 @@ export default async function compareReports(
   const firstCompareResult = await makeCompareCall(
     typeof compareThreshold === 'number' || dryRun,
   );
-  if (typeof compareThreshold !== 'number') {
+  if (typeof compareThreshold !== 'number' || isAsync) {
     // We're not using a threshold -- return results right away
     return firstCompareResult;
   }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -3,39 +3,69 @@ import rimraf from 'rimraf';
 
 import Logger from '../Logger';
 import domRunner from '../domRunner';
+import makeRequest from '../makeRequest';
 import pageRunner from '../pageRunner';
 import remoteRunner from '../remoteRunner';
 import uploadReport from '../uploadReport';
 
-export default async function runCommand(sha, config, { only, link, message }) {
+export default async function runCommand(
+  sha,
+  config,
+  { only, link, message, isAsync },
+) {
   const logger = new Logger();
   const { apiKey, apiSecret, endpoint, project, plugins, pages } = config;
 
   rimraf.sync(config.tmpdir);
   mkdirp.sync(config.tmpdir);
 
-  const staticPlugin = plugins.find((plugin) => typeof plugin.generateStaticPackage === 'function');
-  let snaps;
+  const staticPlugin = plugins.find(
+    (plugin) => typeof plugin.generateStaticPackage === 'function',
+  );
+  let result;
   if (pages) {
-    snaps = await pageRunner(config);
+    result = await pageRunner(config, { isAsync });
   } else if (staticPlugin) {
-    snaps = await remoteRunner(config, staticPlugin);
+    result = await remoteRunner(config, staticPlugin, { isAsync });
   } else {
-    snaps = await domRunner(config, { only });
+    result = await domRunner(config, { only, isAsync });
   }
 
-  logger.start(`Uploading report for ${sha}...`);
-  const { url } = await uploadReport({
-    snaps,
-    sha,
-    endpoint,
-    apiKey,
-    apiSecret,
-    link,
-    message,
-    project,
-  });
-  logger.success();
-  logger.info(`View results at ${url}`);
+  if (isAsync) {
+    logger.start(`Creating async report for ${sha}...`);
+    const allRequestIds = [];
+    result.forEach((item) => allRequestIds.push(...item.result));
+    const { id } = await makeRequest(
+      {
+        url: `${endpoint}/api/async-reports/${sha}`,
+        method: 'POST',
+        json: true,
+        body: {
+          requestIds: allRequestIds,
+          link,
+          message,
+          project,
+        },
+      },
+      { endpoint, apiKey, apiSecret, maxTries: 3 },
+    );
+
+    logger.success();
+    logger.info(`Async report id: ${id}`);
+  } else {
+    logger.start(`Uploading report for ${sha}...`);
+    const { url } = await uploadReport({
+      snaps: result,
+      sha,
+      endpoint,
+      apiKey,
+      apiSecret,
+      link,
+      message,
+      project,
+    });
+    logger.success();
+    logger.info(`View results at ${url}`);
+  }
   logger.info(`Done ${sha}`);
 }

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -98,6 +98,7 @@ async function executeTargetWithPrerender({
   });
 
   const result = await targets[name].execute({
+    targetName: name,
     assetsPackage,
     globalCSS,
     snapPayloads,
@@ -175,6 +176,7 @@ async function generateScreenshots(
           });
         } else {
           result = await targets[name].execute({
+            targetName: name,
             staticPackage,
             globalCSS: cssBlocks,
             apiKey,

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -64,6 +64,7 @@ async function executeTargetWithPrerender({
   apiKey,
   apiSecret,
   endpoint,
+  isAsync,
 }) {
   const { css, snapPayloads } = await processSnapsInBundle(bundleFile, {
     targetName: name,
@@ -98,6 +99,7 @@ async function executeTargetWithPrerender({
   });
 
   const result = await targets[name].execute({
+    asyncResults: isAsync,
     targetName: name,
     assetsPackage,
     globalCSS,
@@ -121,6 +123,7 @@ async function generateScreenshots(
     plugins,
     prerender,
     tmpdir,
+    isAsync,
   },
   bundleFile,
   logger,
@@ -173,9 +176,11 @@ async function generateScreenshots(
             apiSecret,
             endpoint,
             logger,
+            isAsync,
           });
         } else {
           result = await targets[name].execute({
+            asyncResults: isAsync,
             targetName: name,
             staticPackage,
             globalCSS: cssBlocks,
@@ -189,6 +194,9 @@ async function generateScreenshots(
         return { name, result };
       }),
     );
+    if (isAsync) {
+      return results;
+    }
     return constructReport(results);
   } catch (e) {
     logger.fail();
@@ -216,7 +224,7 @@ export default async function domRunner(
     jsdomOptions,
     asyncTimeout,
   },
-  { only, onReady },
+  { only, isAsync, onReady },
 ) {
   const boundGenerateScreenshots = generateScreenshots.bind(null, {
     apiKey,
@@ -227,6 +235,7 @@ export default async function domRunner(
     publicFolders,
     prerender,
     only,
+    isAsync,
     jsdomOptions,
     plugins,
     tmpdir,

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -105,6 +105,7 @@ commander
       message: commander.message,
       author: commander.author,
       dryRun: commander.dryRun,
+      isAsync: commander.async,
     });
     if (commander.link && process.env.HAPPO_GITHUB_USER_CREDENTIALS) {
       await postGithubComment({

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -19,6 +19,7 @@ commander
   .option('-c, --config <path>', 'set config path', configFile)
   .option('-o, --only <component>', 'limit to one component')
   .option('-l, --link <url>', 'provide a link back to the commit')
+  .option('-a, --async', 'process reports/comparisons asynchronously')
   .option(
     '-m, --message <message>',
     'associate the run with a message (e.g. commit subject)',
@@ -48,6 +49,7 @@ commander
     await runCommand(usedSha, await loadUserConfig(commander.config), {
       only: commander.only,
       link: commander.link,
+      isAsync: commander['async'], // eslint-disable-line
       message: commander.message,
     });
     process.exit(0);

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -107,6 +107,10 @@ commander
       dryRun: commander.dryRun,
       isAsync: commander.async,
     });
+    if (commander.async) {
+      new Logger().info(`Async comparison created with ID=${result.id}`);
+      process.exit(0);
+    }
     if (commander.link && process.env.HAPPO_GITHUB_USER_CREDENTIALS) {
       await postGithubComment({
         link: commander.link,

--- a/src/pageRunner.js
+++ b/src/pageRunner.js
@@ -21,6 +21,7 @@ export default async function pagesRunner({
       targetNames.map(async (name) => {
         const startTime = performance.now();
         const result = await targets[name].execute({
+          targetName: name,
           pages,
           apiKey,
           apiSecret,

--- a/src/pageRunner.js
+++ b/src/pageRunner.js
@@ -3,13 +3,10 @@ import { performance } from 'perf_hooks';
 import Logger from './Logger';
 import constructReport from './constructReport';
 
-export default async function pagesRunner({
-  apiKey,
-  apiSecret,
-  endpoint,
-  targets,
-  pages,
-}) {
+export default async function pagesRunner(
+  { apiKey, apiSecret, endpoint, targets, pages },
+  { isAsync } = {},
+) {
   const logger = new Logger();
   try {
     logger.info('Preparing job for remote execution...');
@@ -22,6 +19,7 @@ export default async function pagesRunner({
         const startTime = performance.now();
         const result = await targets[name].execute({
           targetName: name,
+          asyncResults: isAsync,
           pages,
           apiKey,
           apiSecret,
@@ -34,6 +32,9 @@ export default async function pagesRunner({
     );
     logger.start(undefined, { startTime: outerStartTime });
     logger.success();
+    if (isAsync) {
+      return results;
+    }
     return constructReport(results);
   } catch (e) {
     logger.fail();

--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -22,6 +22,7 @@ export default async function remoteRunner(
       targetNames.map(async (name) => {
         const startTime = performance.now();
         const result = await targets[name].execute({
+          targetName: name,
           staticPackage,
           apiKey,
           apiSecret,

--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -6,7 +6,7 @@ import loadCSSFile from './loadCSSFile';
 
 export default async function remoteRunner(
   { apiKey, apiSecret, endpoint, targets, plugins, stylesheets },
-  { generateStaticPackage },
+  { generateStaticPackage, isAsync },
 ) {
   const logger = new Logger();
   try {
@@ -23,6 +23,7 @@ export default async function remoteRunner(
         const startTime = performance.now();
         const result = await targets[name].execute({
           targetName: name,
+          asyncResults: isAsync,
           staticPackage,
           apiKey,
           apiSecret,
@@ -36,6 +37,9 @@ export default async function remoteRunner(
     );
     logger.start(undefined, { startTime: outerStartTime });
     logger.success();
+    if (isAsync) {
+      return results;
+    }
     return constructReport(results);
   } catch (e) {
     logger.fail();

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -71,6 +71,23 @@ describe('#execute', () => {
     });
   });
 
+  describe('with a targetName', () => {
+    it('passes it along', async () => {
+      const target = subject();
+      await target.execute({
+        targetName: 'chrome-large',
+        globalCSS: '* { color: red }',
+        snapPayloads: [{ html: '<div/>' }, { html: '<button/>' }, { html: '<li/>' }],
+        apiKey: 'foobar',
+        apiSecret: 'p@assword',
+        endpoint: 'http://localhost',
+      });
+      expect(makeRequest.mock.calls[0][0].formData.targetName).toEqual(
+        'chrome-large',
+      );
+    });
+  });
+
   describe('when chunks is equal to two', () => {
     beforeEach(() => {
       chunks = 2;


### PR DESCRIPTION
The idea of an async report is that the happo command can finish as soon
as the snap-requests have been initialized. The server will then
construct the report once all snap-requests are done.

So far, only RemoteBrowserTarget is aware of async reports, but going
forward the `happo run` command will know about it too (in some way).