### PR TITLE
Avoid throwing when there are no examples found

### DIFF
--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -73,7 +73,8 @@ async function executeTargetWithPrerender({
     DomProvider,
   });
   if (!snapPayloads.length) {
-    throw new Error('No examples found');
+    console.warn(`No examples found for target ${name}, skipping`);
+    return [];
   }
   const errors = snapPayloads.filter((p) => p.isError);
   if (errors.length === 1) {

--- a/test/integrations/examples/Foo-error-empty-happo.js
+++ b/test/integrations/examples/Foo-error-empty-happo.js
@@ -1,0 +1,1 @@
+export default [];


### PR DESCRIPTION
At Airbnb, we have a pretty complex setup where we have a bunch of
independent projects that are using Happo, and they pull from a shared
Happo configuration. Each component can decide which viewport sizes it
should be rendered in, which maps to a set of Happo targets. We have a
bunch of targets that map to the breakpoints we use in production. Most
components only use a couple of targets, and no projects currently use
all of the targets at once.

Currently, Happo will throw an error if one of the targets does not have
any tests for it. As a workaround, we generate stub tests for each
target. However, that comes with a bunch of overhead that we would be
able to avoid if Happo didn't have this restriction.

I think that throwing and failing the job might help some people
discover that they have a problem with their test setup earlier, but in
practice, I'm not sure that's much more useful than just getting an
empty report. For Airbnb's use-case at least, a much better tradeoff
would be to allow for the flexibility of some targets not having any
examples, and then just logging a warning and skipping over it.

There's a lot of indirection here, so it isn't immediately clear to me
what the early return value should be in this case, but it looks like
the results eventually gets picked up by constructReport, which expects
it to be an array. I can't help but point out that TypeScript would help
us out here.