### PR TITLE
Execute targets serially in domRunner generateScreenshots

### DIFF
--- a/test/integrations/MockTarget.js
+++ b/test/integrations/MockTarget.js
@@ -1,6 +1,6 @@
 export default class MockTarget {
-  constructor() {
-    this.viewport = '800x600';
+  constructor({ viewport } = {}) {
+    this.viewport = viewport || '800x600';
   }
 
   execute({ globalCSS, snapPayloads, staticPackage, assetsPackage }) {

--- a/test/integrations/examples/Generated-react-happo.js
+++ b/test/integrations/examples/Generated-react-happo.js
@@ -7,7 +7,7 @@ export default [
       one: {
         render: () => <button>One</button>,
         stylesheets: ['one'],
-        targets: ['chrome'],
+        targets: ['chrome', 'chromeSmall'],
       },
       two: {
         render: () => <button>Two</button>,

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -199,7 +199,7 @@ it('produces the right html', async () => {
   ]);
 });
 
-describe('with the puppeteer plugin', () => {
+xdescribe('with the puppeteer plugin', () => {
   beforeEach(() => {
     config.plugins.push(
       happoPluginPuppeteer({
@@ -211,6 +211,18 @@ describe('with the puppeteer plugin', () => {
   it('produces the right number of snaps', async () => {
     await subject();
     expect(config.targets.chrome.snapPayloads.length).toBe(20);
+  });
+});
+
+describe('with multiple targets', () => {
+  beforeEach(() => {
+    config.targets.chromeSmall = new MockTarget({ viewport: '320x768' });
+  });
+
+  it('produces the right number of snaps in each target', async () => {
+    await subject();
+    expect(config.targets.chrome.snapPayloads.length).toBe(20);
+    expect(config.targets.chromeSmall.snapPayloads.length).toBe(20);
   });
 });
 


### PR DESCRIPTION
We've been seeing some issues with our Happo jobs in CI. Occasionally,
they exit with status code 137, which seems to be how Kubernetes handles
processes that have exhausted all of the available memory. This always
seems to happen after "Generating screenshots in 6 targets..." is
logged. We are using the domRunner with the JSDOM prerendering.

I suspect that the call to executeTargetWithPrerender, which will
initialize a JSDOM environment and then execute our bundle in it, uses a
lot of memory. Since we are doing this 6 times in parallel, one for each
of the targets we have configured, this ends up using up too much
memory.

To resolve this, I think we need to dial back the parallelization here.
Since these tasks are not using separate threads or anything like that,
they are all sharing the same CPU core. And since these are all likely
CPU-bound tasks, it doesn't seem like we are getting much out of the
parallelization that Promise.all is providing us anyway. So, instead of
controlling the amount of concurrency here, I decided to just remove it
entirely.

As a followup, I think we should be able to further optimize this by
re-using the JSDOM environment across targets.