### PR TITLE
Send API credentials when deep-comparing

### DIFF
--- a/src/authForFetch.js
+++ b/src/authForFetch.js
@@ -1,0 +1,12 @@
+import jwt from 'jsonwebtoken';
+
+export default function authForFetch({ url, apiKey, apiSecret, endpoint }) {
+  if (url.startsWith(endpoint)) {
+    // We're making a request for an image at happo.io (
+    return {
+      bearer: jwt.sign({ key: apiKey }, apiSecret, {
+        header: { kid: apiKey },
+      }),
+    };
+  }
+}

--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -75,6 +75,8 @@ export default async function compareReports(
           endpoint,
           compareThreshold,
           retries: maxTries,
+          apiKey,
+          apiSecret,
         });
         if (!firstDiffDistance) {
           linesToLog.push(

--- a/src/fetchPng.js
+++ b/src/fetchPng.js
@@ -1,10 +1,13 @@
 import { PNG } from 'pngjs';
 import request from 'request';
 
-export default async function fetchPng(url) {
+import authForFetch from './authForFetch';
+
+export default async function fetchPng(url, { apiKey, apiSecret, endpoint }) {
   return new Promise((resolve, reject) => {
     request({
       url,
+      auth: authForFetch({ url, apiKey, apiSecret, endpoint }),
     })
       .on('error', reject)
       .pipe(new PNG())

--- a/src/fetchPngInMemory.js
+++ b/src/fetchPngInMemory.js
@@ -1,18 +1,27 @@
 import { PNG } from 'pngjs';
 import request from 'request';
 
-export default function fetchPngInMemory(url) {
+import authForFetch from './authForFetch';
+
+export default function fetchPngInMemory(url, { apiKey, apiSecret, endpoint }) {
   return new Promise((resolve, reject) => {
-    request(url, { encoding: null }, (error, response, body) => {
-      if (error) {
-        return reject(error);
-      }
-      new PNG({ filterType: 4 }).parse(body, (e, data) => {
-        if (e) {
-          return reject(e);
+    request(
+      {
+        url,
+        auth: authForFetch({ url, apiKey, apiSecret, endpoint }),
+        encoding: null,
+      },
+      (error, response, body) => {
+        if (error) {
+          return reject(error);
         }
-        resolve(data);
-      });
-    });
+        new PNG({ filterType: 4 }).parse(body, (e, data) => {
+          if (e) {
+            return reject(e);
+          }
+          resolve(data);
+        });
+      },
+    );
   });
 }

--- a/test/commands/compareReports-test.js
+++ b/test/commands/compareReports-test.js
@@ -22,7 +22,7 @@ let cliArgs;
 
 beforeEach(() => {
   log = jest.fn();
-  fetchPng.mockImplementation((url) => realFetchPng(url));
+  fetchPng.mockImplementation((url, opts) => realFetchPng(url, opts));
   compareResult = {
     summary: 'Mocked summary',
     equal: false,

--- a/test/compareSnapshots-test.js
+++ b/test/compareSnapshots-test.js
@@ -34,6 +34,8 @@ beforeEach(() => {
       before,
       after,
       endpoint: 'https://dummyimage.com',
+      apiKey: 'foo',
+      apiSecret: 'bar',
       compareThreshold,
     });
 });
@@ -145,9 +147,9 @@ describe('when images are equal', () => {
 describe('when fetchPng fails', () => {
   beforeEach(() => {
     let tries = 0;
-    fetchPng.mockImplementation((url) => {
+    fetchPng.mockImplementation((...args) => {
       if (tries > 1) {
-        return realFetchPng(url);
+        return realFetchPng(...args);
       }
       tries += 1;
       return Promise.reject(new Error('What happened?'));

--- a/test/fetchPng-test.js
+++ b/test/fetchPng-test.js
@@ -1,11 +1,23 @@
+import request from 'request';
+
 import fetchPng from '../src/fetchPng';
+
+jest.mock('request');
+const realRequest = jest.requireActual('request');
 
 let subject;
 let url;
 
 beforeEach(() => {
+  request.mockReset();
+  request.mockImplementation((...args) => realRequest(...args));
   url = 'https://dummyimage.com/200/000/ffffff.png&text=aa';
-  subject = () => fetchPng(url);
+  subject = () =>
+    fetchPng(url, {
+      apiKey: 'foo',
+      apiSecret: 'bar',
+      endpoint: 'https://happo.io',
+    });
 });
 
 it('resolves with a bitmap', async () => {
@@ -13,6 +25,18 @@ it('resolves with a bitmap', async () => {
   expect(bitmap.width).toBe(200);
   expect(bitmap.height).toBe(200);
   expect(bitmap.data.length).toBe(160000);
+});
+
+it('does not send credentials for external urls', async () => {
+  await subject();
+  expect(request.mock.calls[0][0].auth).toBe(undefined);
+});
+
+it('sends credentials for happo urls', async () => {
+  url = 'https://happo.io/a/120/img/happo-io/5ed1580f2dc7243b92c9ff648bbd1824';
+  await subject();
+  expect(request.mock.calls[0][0].auth).not.toBe(undefined);
+  expect(request.mock.calls[0][0].auth.bearer).not.toBe(undefined);
 });
 
 describe('with an invalid url', () => {


### PR DESCRIPTION
When fetching images to deep-compare, there's a chance they aren't
publicly available. If we're talking to a happo.io server, we can send
along the JWT token which will authenticate our requests towards the
happo API.