### PR TITLE
Upload static package separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "5.6.1",
+  "version": "5.7.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "5.7.0-rc.1",
+  "version": "5.7.0-rc.1b",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { Writable } from 'stream';
 
 import Archiver from 'archiver';
@@ -32,7 +33,8 @@ export default function createStaticPackage({ tmpdir, publicFolders }) {
     };
     stream.on('finish', () => {
       const buffer = Buffer.from(data);
-      resolve(buffer);
+      const hash = crypto.createHash('md5').update(buffer).digest('hex');
+      resolve({ buffer, hash });
     });
     archive.pipe(stream);
 


### PR DESCRIPTION
To prevent running into Request Entity Too Large issues, we can upload
static packages separately from the target payloads. This is similar to
what we're already doing for happo-cypress.

For now, I'm only changing the logic for `prerender: false`. Regular
execution will still bake in assets with the payload. I hope to address
this at a later time.