### PR TITLE
Fix resolving PREVIOUS_SHA for github actions push builds

### DIFF
--- a/bin/happo-ci-github-actions
+++ b/bin/happo-ci-github-actions
@@ -10,7 +10,7 @@ ENV_VARS=$(echo "
     if (json.pull_request) {
       console.log(\`export PREVIOUS_SHA=\${json.pull_request.base.sha}\`);
     } else {
-      console.log(\`export PREVIOUS_SHA=\${json.after}\`);
+      console.log(\`export PREVIOUS_SHA=\${json.before}\`);
     }
   }
   if (!process.env.CURRENT_SHA) {


### PR DESCRIPTION
If you set up github actions to run on push events, no comparisons were
made. This was because we resolved to PREVIOUS_SHA to the same sha as
the CURRENT_SHA.

It seems like this was a silly mistake made in the initial commit
(c998d6d4). It could be that we did want the shas to be the same for
master push builds, but I can't find anything in the git commit message
about this, so I'm assuming it's a mistake.

I used this link to see what properties are available for the push
event:
https://developer.github.com/webhooks/event-payloads/