### PR TITLE
Avoid erroring when `devtool: false` is used

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,18 @@ sourceMaps.install({
       return;
     }
     const realPath = filePath.slice(prefix.length);
-    return fs.readFileSync(realPath, 'utf-8');
+
+    try {
+      return fs.readFileSync(realPath, 'utf-8');
+    } catch (e) {
+      // If the file does not exist (e.g. if `devtool: false` is used in
+      // webpack config), just let source-map-support do its normal thing
+      // without erroring out here. This should work because
+      // source-map-support will use the result of the first handler that does
+      // not return null:
+      // https://github.com/evanw/node-source-map-support/blob/50642d69/source-map-support.js#L62-L72
+      return null;
+    }
   },
 });
 


### PR DESCRIPTION
I am attempting to disable sourcemaps in our Happo installation to
improve performance and scalability. This seems to work okay for most of
our projects, but in a couple, I end up with jobs that fail with stack
traces like this:

```
Error: ENOENT: no such file or directory, open '/path/to/repo/build/react-router.js.map'
    at Object.openSync (fs.js:458:3)
    at Object.readFileSync (fs.js:360:35)
    at Array.retrieveFile (/path/to/repo/node_modules/happo.io/build/cli.js:32:25)
    at /path/to/repo/node_modules/source-map-support/source-map-support.js:65:24
    at Array.<anonymous> (/path/to/repo/node_modules/source-map-support/source-map-support.js:179:21)
    at /path/to/repo/node_modules/source-map-support/source-map-support.js:65:24
    at mapSourcePosition (/path/to/repo/node_modules/source-map-support/source-map-support.js:196:21)
    at wrapCallSite (/path/to/repo/node_modules/source-map-support/source-map-support.js:377:20)
    at Function.prepareStackTrace (/path/to/repo/node_modules/source-map-support/source-map-support.js:426:39)
    at maybeOverridePrepareStackTrace (internal/errors.js:91:29)
```

I believe this happens because Happo attempts to read a file that does
not exist, so it errors out here. I think we can make this more
resilient without causing any problems by adding a try/catch around the
readFileSync call.

This should work because source-map-support seems to use the result of
the first handler that does not return null:

https://github.com/evanw/node-source-map-support/blob/50642d69/source-map-support.js#L62-L72