### PR TITLE
Include project name in logs

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -15,6 +15,10 @@ const green = withColorSupport((str) => `\x1b[32m${str}\x1b[0m`);
 const dim = withColorSupport((str) => `\x1b[90m${str}\x1b[0m`);
 const underline = withColorSupport((str) => `\x1b[36m\x1b[4m${str}\x1b[0m`);
 
+export function logTag(project) {
+  return project ? `[${project}] ` : '';
+}
+
 export default class Logger {
   constructor({
     stderrPrint = (str) => process.stderr.write(str),

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,7 +1,7 @@
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 
-import Logger from '../Logger';
+import Logger, { logTag } from '../Logger';
 import domRunner from '../domRunner';
 import makeRequest from '../makeRequest';
 import pageRunner from '../pageRunner';
@@ -32,7 +32,7 @@ export default async function runCommand(
   }
 
   if (isAsync) {
-    logger.start(`Creating async report for ${sha}...`);
+    logger.start(`${logTag(project)}Creating async report for ${sha}...`);
     const allRequestIds = [];
     result.forEach((item) => allRequestIds.push(...item.result));
     const { id } = await makeRequest(
@@ -51,9 +51,9 @@ export default async function runCommand(
     );
 
     logger.success();
-    logger.info(`Async report id: ${id}`);
+    logger.info(`${logTag(project)}Async report id: ${id}`);
   } else {
-    logger.start(`Uploading report for ${sha}...`);
+    logger.start(`${logTag(project)}Uploading report for ${sha}...`);
     const { url } = await uploadReport({
       snaps: result,
       sha,
@@ -65,7 +65,7 @@ export default async function runCommand(
       project,
     });
     logger.success();
-    logger.info(`View results at ${url}`);
+    logger.info(`${logTag(project)}View results at ${url}`);
   }
-  logger.info(`Done ${sha}`);
+  logger.info(`${logTag(project)}Done ${sha}`);
 }

--- a/src/pageRunner.js
+++ b/src/pageRunner.js
@@ -1,19 +1,20 @@
 import { performance } from 'perf_hooks';
 
-import Logger from './Logger';
+import Logger, { logTag } from './Logger';
 import constructReport from './constructReport';
 
 export default async function pagesRunner(
-  { apiKey, apiSecret, endpoint, targets, pages },
+  { apiKey, apiSecret, endpoint, targets, pages, project },
   { isAsync } = {},
 ) {
   const logger = new Logger();
+
   try {
-    logger.info('Preparing job for remote execution...');
+    logger.info(`${logTag(project)}Preparing job for remote execution...`);
     const outerStartTime = performance.now();
     const targetNames = Object.keys(targets);
     const tl = targetNames.length;
-    logger.info(`Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
+    logger.info(`${logTag(project)}Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
     const results = await Promise.all(
       targetNames.map(async (name) => {
         const startTime = performance.now();

--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
 
-import Logger from './Logger';
+import Logger, { logTag } from './Logger';
 import constructReport from './constructReport';
 import createHash from './createHash';
 import loadCSSFile from './loadCSSFile';
@@ -30,13 +30,14 @@ async function uploadStaticPackage({ staticPackage, endpoint, apiKey, apiSecret 
 }
 
 export default async function remoteRunner(
-  { apiKey, apiSecret, endpoint, targets, plugins, stylesheets },
+  { apiKey, apiSecret, endpoint, targets, plugins, stylesheets, project },
   { generateStaticPackage },
   { isAsync },
 ) {
   const logger = new Logger();
+
   try {
-    logger.info('Generating static package...');
+    logger.info(`${logTag(project)}Generating static package...`);
     const staticPackage = await generateStaticPackage();
     const staticPackagePath = await uploadStaticPackage({
       staticPackage,
@@ -48,7 +49,7 @@ export default async function remoteRunner(
     const tl = targetNames.length;
     const cssBlocks = await Promise.all(stylesheets.map(loadCSSFile));
     plugins.forEach(({ css }) => cssBlocks.push(css || ''));
-    logger.info(`Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
+    logger.info(`${logTag(project)}Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
     const outerStartTime = performance.now();
     const results = await Promise.all(
       targetNames.map(async (name) => {
@@ -62,7 +63,7 @@ export default async function remoteRunner(
           endpoint,
           globalCSS: cssBlocks.join('').replace(/\n/g, ''),
         });
-        logger.start(`  - ${name}`, { startTime });
+        logger.start(`  - ${logTag(project)}${name}`, { startTime });
         logger.success();
         return { name, result };
       }),

--- a/test/Logger-test.js
+++ b/test/Logger-test.js
@@ -1,4 +1,4 @@
-import Logger from '../src/Logger';
+import Logger, { logTag } from '../src/Logger';
 
 let subject;
 let stderrPrint;
@@ -68,4 +68,16 @@ it('logs durations with start() and fail()', () => {
   expect(printed).toMatch(/Pizza/);
   expect(printed).toMatch(/Yuck/);
   expect(printed).toMatch(/\(\d+\.\d+ms\)/);
+});
+
+describe('logTag()', () => {
+  it('is empty with no project', () => {
+    expect(logTag(null)).toEqual('');
+    expect(logTag(undefined)).toEqual('');
+    expect(logTag('')).toEqual('');
+  });
+
+  it('is [project] with a project', () => {
+    expect(logTag('pizza')).toEqual('[pizza] ');
+  });
 });


### PR DESCRIPTION

At Airbnb, we are running Happo on a bunch of different projects in
parallel. Since the logs end up getting all mixed together, it is hard
to tell what is actually happening. I'm hoping we can make this better
by including the project name in the log lines if it exists.

I'm not totally in love with this approach, but anything cleaner would
require a deeper refactor of the way logging works in this project, and
I'm not really interested in doing that right now.

