### PR TITLE
Add Node 14 to Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
 node_js:
   - "10"
   - "12"
+  - "14"
 env:
   - WEBPACK_VERSION=5
   - WEBPACK_VERSION=4


### PR DESCRIPTION
Node 14 entered LTS a few weeks ago, so it seems like a good time to
start running the tests against that version now.