### PR TITLE
Log start() and success()/fail() on separate lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "mkdirp": "^0.5.1",
     "parse-srcset": "^1.0.2",
     "pngjs": "^3.4.0",
+    "prettier": "^2.2.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "require-relative": "^0.8.7",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -19,6 +19,12 @@ export function logTag(project) {
   return project ? `[${project}] ` : '';
 }
 
+function printDuration(print, startTime) {
+  if (startTime) {
+    print(dim(` (${(performance.now() - startTime).toFixed(1)}ms)`));
+  }
+}
+
 export default class Logger {
   constructor({
     stderrPrint = (str) => process.stderr.write(str),
@@ -50,18 +56,12 @@ export default class Logger {
     }
   }
 
-  printDuration() {
-    if (this.startTime) {
-      this.print(dim(` (${(performance.now() - this.startTime).toFixed(1)}ms)`));
-    }
-  }
-
   success(msg) {
     this.print(green('✓'));
     if (msg) {
       this.print(green(` ${msg}`));
     }
-    this.printDuration();
+    printDuration(this.print, this.startTime);
     this.print('\n');
   }
 
@@ -70,7 +70,7 @@ export default class Logger {
     if (msg) {
       this.print(red(` ${msg}`));
     }
-    this.printDuration();
+    printDuration(this.print, this.startTime);
     this.print('\n');
   }
 

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,5 +1,3 @@
-import { performance } from 'perf_hooks';
-
 import supportsColor from 'supports-color';
 
 // https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
@@ -21,7 +19,7 @@ export function logTag(project) {
 
 function printDuration(print, startTime) {
   if (startTime) {
-    print(dim(` (${(performance.now() - startTime).toFixed(1)}ms)`));
+    print(dim(` (${(Date.now() - startTime)}ms)`));
   }
 }
 
@@ -33,6 +31,7 @@ export default class Logger {
     this.print = print;
     this.stderrPrint = stderrPrint;
     this.startTime = undefined;
+    this.startMsg = undefined;
   }
 
   mute() {
@@ -50,28 +49,44 @@ export default class Logger {
   }
 
   start(msg, { startTime } = {}) {
-    this.startTime = startTime || performance.now();
+    this.startTime = startTime || Date.now();
+    this.startMsg = msg;
     if (msg) {
-      this.print(`${msg} `);
+      this.print(`Starting: ${msg} `);
+      this.print('\n');
     }
   }
 
   success(msg) {
     this.print(green('✓'));
+
+    if (this.startMsg) {
+      this.print(green(` ${this.startMsg}:`));
+    }
+
     if (msg) {
       this.print(green(` ${msg}`));
     }
     printDuration(this.print, this.startTime);
     this.print('\n');
+
+    this.startMsg = undefined;
   }
 
   fail(msg) {
     this.print(red('✗'));
+
+    if (this.startMsg) {
+      this.print(red(` ${this.startMsg}:`));
+    }
+
     if (msg) {
       this.print(red(` ${msg}`));
     }
     printDuration(this.print, this.startTime);
     this.print('\n');
+
+    this.startMsg = undefined;
   }
 
   error(e) {

--- a/test/Logger-test.js
+++ b/test/Logger-test.js
@@ -21,53 +21,49 @@ it('works without injected printers', () => {
 
 it('does not print to stdout on errors', () => {
   subject().error(new Error('foo'));
-  expect(print.mock.calls.length).toBe(0);
+  expect(print).toHaveBeenCalledTimes(0);
 });
 
 it('logs errors with stacks', () => {
   const error = new Error('damn');
   error.stack = 'foobar';
   subject().error(error);
-  // We have to use `toMatch` here because the string is wrapped with color
+  // We use `stringContaining` here because the string is wrapped with color
   // instruction characters
-  expect(stderrPrint.mock.calls[0][0]).toMatch(/foobar/);
+  expect(stderrPrint).toHaveBeenNthCalledWith(1, expect.stringContaining('foobar'));
 });
 
 it('logs errors without stacks', () => {
   const error = new Error('damn');
   delete error.stack;
   subject().error(error);
-  // We have to use `toMatch` here because the string is wrapped with color
+  // We use `stringContaining` here because the string is wrapped with color
   // instruction characters
-  expect(stderrPrint.mock.calls[0][0]).toMatch(/damn/);
+  expect(stderrPrint).toHaveBeenNthCalledWith(1, expect.stringContaining('damn'));
 });
 
 it('logs durations with start() and success()', () => {
   const logger = subject();
 
   logger.start('Pizza');
-  let printed = print.mock.calls.map(([str]) => str).join('');
-  expect(printed).toMatch(/Pizza/);
+  expect(print).toHaveBeenNthCalledWith(1, expect.stringContaining('Pizza'));
+  print.mockReset();
 
   logger.success('Yum');
-  printed = print.mock.calls.map(([str]) => str).join('');
-  expect(printed).toMatch(/Pizza/);
-  expect(printed).toMatch(/Yum/);
-  expect(printed).toMatch(/\(\d+\.\d+ms\)/);
+  expect(print).toHaveBeenNthCalledWith(2, expect.stringContaining('Yum'));
+  expect(print).toHaveBeenNthCalledWith(3, expect.stringMatching(/\(\d+\.\d+ms\)/));
 });
 
 it('logs durations with start() and fail()', () => {
   const logger = subject();
 
   logger.start('Pizza');
-  let printed = print.mock.calls.map(([str]) => str).join('');
-  expect(printed).toMatch(/Pizza/);
+  expect(print).toHaveBeenNthCalledWith(1, expect.stringContaining('Pizza'));
+  print.mockReset();
 
   logger.fail('Yuck');
-  printed = print.mock.calls.map(([str]) => str).join('');
-  expect(printed).toMatch(/Pizza/);
-  expect(printed).toMatch(/Yuck/);
-  expect(printed).toMatch(/\(\d+\.\d+ms\)/);
+  expect(print).toHaveBeenNthCalledWith(2, expect.stringContaining('Yuck'));
+  expect(print).toHaveBeenNthCalledWith(3, expect.stringMatching(/\(\d+\.\d+ms\)/));
 });
 
 describe('logTag()', () => {

--- a/test/Logger-test.js
+++ b/test/Logger-test.js
@@ -24,6 +24,11 @@ it('does not print to stdout on errors', () => {
   expect(print).toHaveBeenCalledTimes(0);
 });
 
+it('prints to stderr on errors', () => {
+  subject().error(new Error('foo'));
+  expect(stderrPrint).toHaveBeenCalledTimes(2);
+});
+
 it('logs errors with stacks', () => {
   const error = new Error('damn');
   error.stack = 'foobar';
@@ -47,11 +52,13 @@ it('logs durations with start() and success()', () => {
 
   logger.start('Pizza');
   expect(print).toHaveBeenNthCalledWith(1, expect.stringContaining('Pizza'));
+  expect(stderrPrint).toHaveBeenCalledTimes(0);
   print.mockReset();
 
   logger.success('Yum');
   expect(print).toHaveBeenNthCalledWith(2, expect.stringContaining('Yum'));
   expect(print).toHaveBeenNthCalledWith(3, expect.stringMatching(/\(\d+\.\d+ms\)/));
+  expect(stderrPrint).toHaveBeenCalledTimes(0);
 });
 
 it('logs durations with start() and fail()', () => {
@@ -59,11 +66,13 @@ it('logs durations with start() and fail()', () => {
 
   logger.start('Pizza');
   expect(print).toHaveBeenNthCalledWith(1, expect.stringContaining('Pizza'));
+  expect(stderrPrint).toHaveBeenCalledTimes(0);
   print.mockReset();
 
   logger.fail('Yuck');
   expect(print).toHaveBeenNthCalledWith(2, expect.stringContaining('Yuck'));
   expect(print).toHaveBeenNthCalledWith(3, expect.stringMatching(/\(\d+\.\d+ms\)/));
+  expect(stderrPrint).toHaveBeenCalledTimes(0);
 });
 
 describe('logTag()', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5255,6 +5255,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
+  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+
 pretty-format@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.0.tgz#1e1030e3c70e3ac1c568a5fd15627671ea159391"


### PR DESCRIPTION


In https://github.com/happo/happo.io/pull/189 we made some improvments
to make the logs clearer when running Happo on multiple projects in
parallel. After landing this change, I noticed that since we leave
lines open with start() to be completed by success() or fail(), we
still get some logs that are a bit weird or confusing.

To make this better, I am changing start() to always log a newline,
and then teaching success() and fail() to include the start message if
it exists.

Now that the logger is getting a bit more complex in its output, I
decided that it would be helpful to have full examples of what it is
logging in the test suite, and Jest inline snapshots work well for
this. In order for the timings to be stable, we need to mock out the
timer, and Jest mock timers will mock out Date, but not perf_hooks, so
I am also switching to the slightly less granular Date.now at this
time. I don't think we really care about anything less than 1ms
anyway, so this should be just fine.

