### PR TITLE
Add `notify` option

### DIFF
--- a/src/commands/compareReports.js
+++ b/src/commands/compareReports.js
@@ -20,7 +20,7 @@ export default async function compareReports(
   sha1,
   sha2,
   { apiKey, apiSecret, endpoint, project, compareThreshold },
-  { link, message, author, dryRun, isAsync },
+  { link, message, author, dryRun, isAsync, notify },
   log = console.log,
   maxTries = 5,
 ) {
@@ -37,6 +37,7 @@ export default async function compareReports(
           project,
           skipStatusPost,
           isAsync,
+          notify,
         },
       },
       { apiKey, apiSecret, maxTries },

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -14,7 +14,7 @@ import startJobCommand from './commands/startJob';
 import postGithubComment from './postGithubComment';
 import uploadReport from './uploadReport';
 
-const { HAPPO_IS_ASYNC: RAW_HAPPO_IS_ASYNC } = process.env;
+const { HAPPO_NOTIFY, HAPPO_IS_ASYNC: RAW_HAPPO_IS_ASYNC } = process.env;
 const HAPPO_IS_ASYNC = RAW_HAPPO_IS_ASYNC === 'true';
 
 commander
@@ -23,6 +23,10 @@ commander
   .option('-o, --only <component>', 'limit to one component')
   .option('-l, --link <url>', 'provide a link back to the commit')
   .option('-a, --async', 'process reports/comparisons asynchronously')
+  .option(
+    '-n, --notify <emails>',
+    'one or more (comma-separated) email addresses to notify with results',
+  )
   .option(
     '-m, --message <message>',
     'associate the run with a message (e.g. commit subject)',
@@ -105,11 +109,13 @@ commander
   .action(async (sha1, sha2) => {
     const config = await loadUserConfig(commander.config);
     const isAsync = commander.async || HAPPO_IS_ASYNC;
+    const notify = commander.notify || HAPPO_NOTIFY;
     const result = await compareReportsCommand(sha1, sha2, config, {
       link: commander.link,
       message: commander.message,
       author: commander.author,
       dryRun: commander.dryRun,
+      notify,
       isAsync,
     });
     if (isAsync) {

--- a/test/commands/compareReports-test.js
+++ b/test/commands/compareReports-test.js
@@ -61,6 +61,15 @@ it('succeeds', async () => {
   ]);
 });
 
+describe('when `notify` is set', () => {
+  it('sends that param to the happo api', async () => {
+    cliArgs.notify = 'foo@bar.com';
+    await subject();
+    expect(makeRequest.mock.calls.length).toBe(2);
+    expect(makeRequest.mock.calls[1][0].body.notify).toEqual('foo@bar.com');
+  });
+});
+
 describe('when fetchPng fails', () => {
   beforeEach(() => {
     fetchPng.mockImplementation(() => Promise.reject(new Error('mocked')));


### PR DESCRIPTION
This new option can be used with the compare call to send emails to
people when a comparison is ready.