### PR TITLE
Upload assets for prerender runs separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "6.5.0-rc.2",
+  "version": "6.5.0-rc.3",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "6.5.0-rc.1",
+  "version": "6.5.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "6.4.0",
+  "version": "6.5.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -99,14 +99,6 @@ async function executeTargetWithPrerender({
     console.warn(`${logTag(project)}No examples found for target ${name}, skipping`);
     return [];
   }
-  const errors = snapPayloads.filter((p) => p.isError);
-  if (errors.length === 1) {
-    throw errors[0];
-  }
-  if (errors.length > 1) {
-    throw new MultipleErrors(errors);
-  }
-
   if (VERBOSE === 'true') {
     logTargetResults({ name, globalCSS, snapPayloads, project });
   }
@@ -214,6 +206,15 @@ async function generateScreenshots(
           viewport: targets[name].viewport,
           DomProvider,
         });
+
+        const errors = snapPayloads.filter((p) => p.isError);
+        if (errors.length === 1) {
+          throw errors[0];
+        }
+        if (errors.length > 1) {
+          throw new MultipleErrors(errors);
+        }
+
         const globalCSS = cssBlocks.concat([{ css }]);
 
         const { buffer, hash } = await prepareAssetsPackage({
@@ -231,9 +232,7 @@ async function generateScreenshots(
           }
         } else {
           if (VERBOSE === 'true') {
-            console.log(
-              `${logTag(project)}Uploading assets package ${hash}`,
-            );
+            console.log(`${logTag(project)}Uploading assets package ${hash}`);
           }
           assetsPackage = await uploadAssets({
             endpoint,

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -222,15 +222,29 @@ async function generateScreenshots(
           publicFolders,
         });
 
-        const assetsPackage =
-          knownAssetPackagePaths[hash] ||
-          (await uploadAssets({
+        let assetsPackage = knownAssetPackagePaths[hash];
+        if (assetsPackage) {
+          if (VERBOSE === 'true') {
+            console.log(
+              `${logTag(project)}Assets package ${hash} has already been uploaded`,
+            );
+          }
+        } else {
+          if (VERBOSE === 'true') {
+            console.log(
+              `${logTag(project)}Uploading assets package ${hash}`,
+            );
+          }
+          assetsPackage = await uploadAssets({
             endpoint,
             apiKey,
             apiSecret,
             hash,
             buffer,
-          }));
+          });
+          knownAssetPackagePaths[hash] = assetsPackage;
+        }
+
         /* eslint-enable no-await-in-loop */
 
         snapPayloads.forEach((item) => {

--- a/src/prepareAssetsPackage.js
+++ b/src/prepareAssetsPackage.js
@@ -1,4 +1,5 @@
 import { Writable } from 'stream';
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -24,7 +25,8 @@ function makePackage({ paths, publicFolders }) {
     };
     stream.on('finish', () => {
       const buffer = Buffer.from(data);
-      resolve(buffer);
+      const hash = crypto.createHash('md5').update(buffer).digest('hex');
+      resolve({ buffer, hash });
     });
     archive.pipe(stream);
 
@@ -72,7 +74,11 @@ function makePackage({ paths, publicFolders }) {
   });
 }
 
-export default function prepareAssetsPackage({ globalCSS, snapPayloads, publicFolders }) {
+export default function prepareAssetsPackage({
+  globalCSS,
+  snapPayloads,
+  publicFolders,
+}) {
   const paths = {};
   globalCSS.forEach(({ css, source }) => {
     findCSSAssetPaths({ css, source }).forEach(({ assetPath, resolvePath }) => {

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -73,7 +73,7 @@ beforeEach(() => {
 
 it('sends the project name in the request', async () => {
   await subject();
-  expect(makeRequest.mock.calls[0][0].body.project).toEqual('the project');
+  expect(makeRequest.mock.calls[1][0].body.project).toEqual('the project');
 });
 
 it('produces the right html', async () => {

--- a/test/prepareAssetsPackage-test.js
+++ b/test/prepareAssetsPackage-test.js
@@ -35,7 +35,8 @@ beforeEach(() => {
 
 it('creates a package when there are assets', async () => {
   const result = await subject();
-  expect(result).not.toBe(undefined);
+  expect(result.buffer).not.toBe(undefined);
+  expect(result.hash).not.toBe(undefined);
 });
 
 it('creates consistent results', async () => {
@@ -50,11 +51,12 @@ it('creates consistent results', async () => {
 it('does not fail when files are missing', async () => {
   const result = await subject();
   publicFolders = [path.join(__dirname, 'foobar')];
-  expect(result).not.toBe(undefined);
+  expect(result.buffer).not.toBe(undefined);
+  expect(result.hash).not.toBe(undefined);
 });
 
 it('picks out the right files', async () => {
-  const buffer = await subject();
+  const { buffer } = await subject();
   const zip = new AdmZip(buffer);
   expect(zip.getEntries().map(({ entryName }) => entryName)).toEqual([
     '1x1.jpg', // this is in the root because the css is always served from the root on happo workers


### PR DESCRIPTION

To reduce traffic towards s3 and avoid having to be throttled, we can
attempt to reuse asset packages between runs. This is already done for
static runs (e.g. storybook) but it's a little trickier to reuse things
between prerendered runs because assets might differ based on the size
of the viewport. Still, we can use a cache of known asset packages and
avoid the upload if the package is known.

I plan on pairing this change with an update to happo servers as well,
where we avoid the s3 upload if we come across a package that we've seen
and uploaded before. The cache used here is simply local to the cli
invocation, but a cache on happo servers can live longer than that.