### PR TITLE
Add HAPPO_SKIP_START_JOB to happo-ci script

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -9,6 +9,7 @@ set -eou pipefail
 # Initialize optional env variables
 INSTALL_CMD=${INSTALL_CMD:-}
 HAPPO_IS_ASYNC=${HAPPO_IS_ASYNC:-}
+HAPPO_SKIP_START_JOB=${HAPPO_SKIP_START_JOB:-}
 HAPPO_GIT_COMMAND=${HAPPO_GIT_COMMAND:-git}
 HAPPO_COMMAND=${HAPPO_COMMAND:-"node_modules/happo.io/build/cli.js"}
 
@@ -27,6 +28,7 @@ echo "CURRENT_SHA: ${CURRENT_SHA}"
 echo "CHANGE_URL: ${CHANGE_URL}"
 echo "INSTALL_CMD: ${INSTALL_CMD}"
 echo "HAPPO_IS_ASYNC: ${HAPPO_IS_ASYNC}"
+echo "HAPPO_SKIP_START_JOB: ${HAPPO_SKIP_START_JOB}"
 echo "HAPPO_GIT_COMMAND: ${HAPPO_GIT_COMMAND}"
 echo "HAPPO_COMMAND: ${HAPPO_COMMAND}"
 echo "HAPPO_FALLBACK_SHAS: ${HAPPO_FALLBACK_SHAS}"
@@ -92,9 +94,13 @@ fi
 COMMIT_SUBJECT="$(${HAPPO_GIT_COMMAND} show -s --format=%s)"
 COMMIT_AUTHOR="$(${HAPPO_GIT_COMMAND} show -s --format=%ae)"
 
-"$HAPPO_COMMAND" start-job "$PREVIOUS_SHA" "$CURRENT_SHA" \
-  --link "${CHANGE_URL}" \
-  --message "${COMMIT_SUBJECT}"
+# If orchestration is being used and there is a guarantee that the orchestrate
+# endpoint will be hit before this runs, this start-job step can be skipped.
+if [ -z "$HAPPO_SKIP_START_JOB" ]; then
+  "$HAPPO_COMMAND" start-job "$PREVIOUS_SHA" "$CURRENT_SHA" \
+    --link "${CHANGE_URL}" \
+    --message "${COMMIT_SUBJECT}"
+fi
 
 run-happo "$CURRENT_SHA"
 


### PR DESCRIPTION
At Airbnb, we are using Happo with orchestration. When we originally
started using this, we had a race condition between the orchestration
API call and when the projects would start running Happo. In this
scenario, we needed to always run the start-job command, which ensures
that a job is created for these, and if orchestration is used then it is
smart enough to combine the separate start-job calls into a single
orchestrated job.

More recently, we've observed some database contention partly due to our
scale. In my investigation, I realized that we have since resolved this
race condition and now have a guarantee that the orchestrate endpoint
will be called before Happo is run on any project in the PR. This means
that we can save a bunch of work by skipping this start-job command.

To make this skipping possible, I am adding a check for a
HAPPO_SKIP_START_JOB environment variable. This will allow us to switch
this behavior off and on if necessary.