### PR TITLE
Add *.png to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -59,3 +59,6 @@ typings/
 
 # Test files
 test/
+
+# Unnecessary images
+*.png


### PR DESCRIPTION
When I published the latest version, I noticed that most of the package
size comes from a few PNG files that aren't really needed by consumers.

```
npm notice 16.6kB  happo-accept.png
npm notice 22.0kB  happo-dot-io-logo.png
npm notice 168.0kB happo-report.png
npm notice 49.9kB  happo-status-accepted.png
npm notice 150.8kB happo-status-diffs.png
```

Ignoring these will help keep the package size nice and small.