### PR TITLE
Make async mode the default in CI

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -14,10 +14,12 @@ HAPPO_GIT_COMMAND=${HAPPO_GIT_COMMAND:-git}
 HAPPO_COMMAND=${HAPPO_COMMAND:-"node_modules/happo.io/build/cli.js"}
 
 # Make sure we use the full commit shas
-if [ -n "$PREVIOUS_SHA" ]; then
+if [ -n "$PREVIOUS_SHA" ] && [ ${#PREVIOUS_SHA} -ne 40 ]; then
   PREVIOUS_SHA="$(${HAPPO_GIT_COMMAND} rev-parse "$PREVIOUS_SHA")"
 fi
-CURRENT_SHA="$(${HAPPO_GIT_COMMAND} rev-parse "$CURRENT_SHA")"
+if [ ${#CURRENT_SHA} -ne 40 ]; then
+  CURRENT_SHA="$(${HAPPO_GIT_COMMAND} rev-parse "$CURRENT_SHA")"
+fi
 
 HAPPO_FALLBACK_SHAS_COUNT=${HAPPO_FALLBACK_SHAS_COUNT:-50}
 HAPPO_FALLBACK_SHAS=${HAPPO_FALLBACK_SHAS:-$(${HAPPO_GIT_COMMAND} log --format=%H --first-parent --max-count=${HAPPO_FALLBACK_SHAS_COUNT} "$PREVIOUS_SHA"^ || true)}

--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -8,7 +8,7 @@ set -eou pipefail
 
 # Initialize optional env variables
 INSTALL_CMD=${INSTALL_CMD:-}
-HAPPO_IS_ASYNC=${HAPPO_IS_ASYNC:-}
+HAPPO_IS_ASYNC=${HAPPO_IS_ASYNC:-true}
 HAPPO_SKIP_START_JOB=${HAPPO_SKIP_START_JOB:-}
 HAPPO_GIT_COMMAND=${HAPPO_GIT_COMMAND:-git}
 HAPPO_COMMAND=${HAPPO_COMMAND:-"node_modules/happo.io/build/cli.js"}
@@ -63,7 +63,7 @@ run-happo() {
   SHA=$1
   RUN_HAPPO_CHECK="false"
 
-  if [ -z "$HAPPO_IS_ASYNC" ]; then
+  if [ "$HAPPO_IS_ASYNC" = "false" ]; then
     HEAD_SHA=$(${HAPPO_GIT_COMMAND} rev-parse HEAD)
     if [ "$HEAD_SHA" != "$SHA" ]; then
       RUN_HAPPO_CHECK="true"
@@ -106,7 +106,7 @@ fi
 
 run-happo "$CURRENT_SHA"
 
-if [ -z "$HAPPO_IS_ASYNC" ]; then
+if [ "$HAPPO_IS_ASYNC" = "false" ]; then
   # Check if we need to generate a baseline. In some cases, the baseline is
   # already there (some other PR uploaded it), and we can just use the existing
   # one.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "6.7.0",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
+  "engines": {
+    "node": ">=10"
+  },
   "bin": {
     "happo": "./build/cli.js",
     "happo-ci-travis": "./bin/happo-ci-travis",
@@ -21,13 +24,7 @@
     "type": "git",
     "url": "git+https://github.com/happo/happo.io.git"
   },
-  "keywords": [
-    "visual",
-    "diffing",
-    "ui",
-    "testing",
-    "snapshots"
-  ],
+  "keywords": ["visual", "diffing", "ui", "testing", "snapshots"],
   "author": "Henric Trotzig",
   "license": "MIT",
   "bugs": {
@@ -36,15 +33,9 @@
   "homepage": "https://github.com/happo/happo.io#readme",
   "jest": {
     "testEnvironment": "node",
-    "setupFilesAfterEnv": [
-      "./test/jestSetup.js"
-    ],
-    "testMatch": [
-      "**/*-test.js*"
-    ],
-    "testPathIgnorePatterns": [
-      "node_modules"
-    ]
+    "setupFilesAfterEnv": ["./test/jestSetup.js"],
+    "testMatch": ["**/*-test.js*"],
+    "testPathIgnorePatterns": ["node_modules"]
   },
   "prettier": {
     "printWidth": 85,

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -115,6 +115,30 @@ describe('when there is a report for PREVIOUS_SHA', () => {
       'show -s --format=%s',
     ]);
   });
+
+  describe('when HAPPO_SKIP_START_JOB is set', () => {
+    beforeEach(() => {
+      env.HAPPO_SKIP_START_JOB = 'true';
+    });
+
+    it('runs the right happo commands', () => {
+      subject();
+      expect(getCliLog()).toEqual([
+        'run bar --link http://foo.bar/ --message Commit message',
+        'has-report foo',
+        'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
+      ]);
+      expect(getGitLog()).toEqual([
+        'rev-parse foo',
+        'rev-parse bar',
+        'log --format=%H --first-parent --max-count=50 foo^',
+        'show -s --format=%s',
+        'show -s --format=%ae',
+        'rev-parse HEAD',
+        'show -s --format=%s',
+      ]);
+    });
+  });
 });
 
 describe('when there is no report for PREVIOUS_SHA', () => {

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -140,6 +140,42 @@ describe('when there is a report for PREVIOUS_SHA', () => {
     });
   });
 });
+describe('when CURRENT_SHA has the right hash length', () => {
+  beforeEach(() => {
+    env.CURRENT_SHA = '93a000afa511ff777143ff2aab48748429c2666a';
+  });
+
+  it('does not rev-parse to get the full sha', () => {
+    subject();
+    expect(getGitLog()).toEqual([
+      'rev-parse foo',
+      'log --format=%H --first-parent --max-count=50 foo^',
+      'show -s --format=%s',
+      'show -s --format=%ae',
+      'rev-parse HEAD',
+      'checkout --force --quiet 93a000afa511ff777143ff2aab48748429c2666a',
+      'show -s --format=%s',
+    ]);
+  });
+
+  describe('when PREVIOUS_SHA is of the right length as well', () => {
+    beforeEach(() => {
+      env.PREVIOUS_SHA = '748e8b6a19831f61066a1ba4eb26ecd2ffa98879';
+    });
+
+    it('does not rev-parse to get the full sha', () => {
+      subject();
+      expect(getGitLog()).toEqual([
+        'log --format=%H --first-parent --max-count=50 748e8b6a19831f61066a1ba4eb26ecd2ffa98879^',
+        'show -s --format=%s',
+        'show -s --format=%ae',
+        'rev-parse HEAD',
+        'checkout --force --quiet 93a000afa511ff777143ff2aab48748429c2666a',
+        'show -s --format=%s',
+      ]);
+    });
+  });
+});
 
 describe('when there is no report for PREVIOUS_SHA', () => {
   beforeEach(() => {

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -90,7 +90,6 @@ describe('when CURRENT_SHA and PREVIOUS_SHA is the same', () => {
       'rev-parse bar',
       'rev-parse bar',
       'log --format=%H --first-parent --max-count=50 bar^',
-      'rev-parse HEAD',
       'show -s --format=%s',
     ]);
   });
@@ -102,7 +101,6 @@ describe('when there is a report for PREVIOUS_SHA', () => {
     expect(getCliLog()).toEqual([
       'start-job foo bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
-      'has-report foo',
       'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
     ]);
     expect(getGitLog()).toEqual([
@@ -111,19 +109,19 @@ describe('when there is a report for PREVIOUS_SHA', () => {
       'log --format=%H --first-parent --max-count=50 foo^',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'rev-parse HEAD',
       'show -s --format=%s',
     ]);
   });
 
-  describe('when HAPPO_SKIP_START_JOB is set', () => {
+  describe('when HAPPO_IS_ASYNC=false', () => {
     beforeEach(() => {
-      env.HAPPO_SKIP_START_JOB = 'true';
+      env.HAPPO_IS_ASYNC = 'false';
     });
 
     it('runs the right happo commands', () => {
       subject();
       expect(getCliLog()).toEqual([
+        'start-job foo bar --link http://foo.bar/ --message Commit message',
         'run bar --link http://foo.bar/ --message Commit message',
         'has-report foo',
         'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
@@ -135,6 +133,28 @@ describe('when there is a report for PREVIOUS_SHA', () => {
         'show -s --format=%s',
         'show -s --format=%ae',
         'rev-parse HEAD',
+        'show -s --format=%s',
+      ]);
+    });
+  });
+
+  describe('when HAPPO_SKIP_START_JOB is set', () => {
+    beforeEach(() => {
+      env.HAPPO_SKIP_START_JOB = 'true';
+    });
+
+    it('runs the right happo commands', () => {
+      subject();
+      expect(getCliLog()).toEqual([
+        'run bar --link http://foo.bar/ --message Commit message',
+        'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
+      ]);
+      expect(getGitLog()).toEqual([
+        'rev-parse foo',
+        'rev-parse bar',
+        'log --format=%H --first-parent --max-count=50 foo^',
+        'show -s --format=%s',
+        'show -s --format=%ae',
         'show -s --format=%s',
       ]);
     });
@@ -152,10 +172,27 @@ describe('when CURRENT_SHA has the right hash length', () => {
       'log --format=%H --first-parent --max-count=50 foo^',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'rev-parse HEAD',
-      'checkout --force --quiet 93a000afa511ff777143ff2aab48748429c2666a',
       'show -s --format=%s',
     ]);
+  });
+
+  describe('when HAPPO_IS_ASYNC is false', () => {
+    beforeEach(() => {
+      env.HAPPO_IS_ASYNC = false;
+    });
+
+    it('does not rev-parse to get the full sha', () => {
+      subject();
+      expect(getGitLog()).toEqual([
+        'rev-parse foo',
+        'log --format=%H --first-parent --max-count=50 foo^',
+        'show -s --format=%s',
+        'show -s --format=%ae',
+        'rev-parse HEAD',
+        'checkout --force --quiet 93a000afa511ff777143ff2aab48748429c2666a',
+        'show -s --format=%s',
+      ]);
+    });
   });
 
   describe('when PREVIOUS_SHA is of the right length as well', () => {
@@ -169,8 +206,6 @@ describe('when CURRENT_SHA has the right hash length', () => {
         'log --format=%H --first-parent --max-count=50 748e8b6a19831f61066a1ba4eb26ecd2ffa98879^',
         'show -s --format=%s',
         'show -s --format=%ae',
-        'rev-parse HEAD',
-        'checkout --force --quiet 93a000afa511ff777143ff2aab48748429c2666a',
         'show -s --format=%s',
       ]);
     });
@@ -182,13 +217,11 @@ describe('when there is no report for PREVIOUS_SHA', () => {
     env.PREVIOUS_SHA = 'no-report';
   });
 
-  it('runs the right happo commands', () => {
+  it('does not checkout anything, runs a single report', () => {
     subject();
     expect(getCliLog()).toEqual([
       'start-job no-report bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
-      'has-report no-report',
-      'run no-report --link http://foo.bar/ --message Commit message',
       'compare no-report bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
     ]);
     expect(getGitLog()).toEqual([
@@ -197,25 +230,21 @@ describe('when there is no report for PREVIOUS_SHA', () => {
       'log --format=%H --first-parent --max-count=50 no-report^',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'rev-parse HEAD',
       'show -s --format=%s',
-      'rev-parse HEAD',
-      'checkout --force --quiet no-report',
-      'show -s --format=%s',
-      'checkout --force --quiet bar',
     ]);
   });
 
-  describe('when HAPPO_IS_ASYNC', () => {
+  describe('when HAPPO_IS_ASYNC=false', () => {
     beforeEach(() => {
-      env.HAPPO_IS_ASYNC = 'true';
+      env.HAPPO_IS_ASYNC = 'false';
     });
-
-    it('does not checkout anything, runs a single report', () => {
+    it('runs the right happo commands', () => {
       subject();
       expect(getCliLog()).toEqual([
         'start-job no-report bar --link http://foo.bar/ --message Commit message',
         'run bar --link http://foo.bar/ --message Commit message',
+        'has-report no-report',
+        'run no-report --link http://foo.bar/ --message Commit message',
         'compare no-report bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
       ]);
       expect(getGitLog()).toEqual([
@@ -224,7 +253,12 @@ describe('when there is no report for PREVIOUS_SHA', () => {
         'log --format=%H --first-parent --max-count=50 no-report^',
         'show -s --format=%s',
         'show -s --format=%ae',
+        'rev-parse HEAD',
         'show -s --format=%s',
+        'rev-parse HEAD',
+        'checkout --force --quiet no-report',
+        'show -s --format=%s',
+        'checkout --force --quiet bar',
       ]);
     });
   });
@@ -240,7 +274,6 @@ describe('when the compare call fails', () => {
     expect(getCliLog()).toEqual([
       'start-job fail bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
-      'has-report fail',
       'compare fail bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
     ]);
     expect(getGitLog()).toEqual([
@@ -249,15 +282,15 @@ describe('when the compare call fails', () => {
       'log --format=%H --first-parent --max-count=50 fail^',
       'show -s --format=%s',
       'show -s --format=%ae',
-      'rev-parse HEAD',
       'show -s --format=%s',
     ]);
   });
 });
 
-describe('when happo.io is not installed for the PREVIOUS_SHA', () => {
+describe('when happo.io is not installed for the PREVIOUS_SHA and HAPPO_IS_ASYNC=false', () => {
   beforeEach(() => {
     env.PREVIOUS_SHA = 'no-happo';
+    env.HAPPO_IS_ASYNC = 'false';
   });
 
   it('runs the right happo commands', () => {


### PR DESCRIPTION
When the HAPPO_IS_ASYNC environment variable is set to "true", the
happo-ci script won't check out the previous commit and create a report.
Instead, we rely on that report (or a fallback) to already exist.

Async runs are faster and frees up valuable CI runtime since they don't
wait for the screenshots to be ready before exiting.

This is a breaking change for anyone using the happo-ci script directly,
the happo-ci-travis script, and the happo-ci-circleci script. The
happo-ci-github-actions script was already using async mode (it was
added later on and had async from the start).