### PR TITLE
Add ability to inject custom webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "6.7.0",
+  "version": "6.8.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "engines": {
@@ -24,7 +24,13 @@
     "type": "git",
     "url": "git+https://github.com/happo/happo.io.git"
   },
-  "keywords": ["visual", "diffing", "ui", "testing", "snapshots"],
+  "keywords": [
+    "visual",
+    "diffing",
+    "ui",
+    "testing",
+    "snapshots"
+  ],
   "author": "Henric Trotzig",
   "license": "MIT",
   "bugs": {
@@ -33,9 +39,15 @@
   "homepage": "https://github.com/happo/happo.io#readme",
   "jest": {
     "testEnvironment": "node",
-    "setupFilesAfterEnv": ["./test/jestSetup.js"],
-    "testMatch": ["**/*-test.js*"],
-    "testPathIgnorePatterns": ["node_modules"]
+    "setupFilesAfterEnv": [
+      "./test/jestSetup.js"
+    ],
+    "testMatch": [
+      "**/*-test.js*"
+    ],
+    "testPathIgnorePatterns": [
+      "node_modules"
+    ]
   },
   "prettier": {
     "printWidth": 85,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "6.8.0-rc.1",
+  "version": "6.8.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "engines": {

--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -34,3 +34,4 @@ export function customizeWebpackConfig(config) {
   // always there.
   return config;
 }
+export const webpack = undefined;

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -421,7 +421,7 @@ export default async function domRunner(
 
   const bundleFile = await createWebpackBundle(
     entryFile,
-    { type, customizeWebpackConfig, plugins, tmpdir },
+    { type, customizeWebpackConfig, plugins, tmpdir, webpack },
     {},
   );
   logger.success();

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -324,6 +324,7 @@ export default async function domRunner(
     jsdomOptions,
     asyncTimeout,
     project,
+    webpack,
   },
   { only, isAsync, onReady },
 ) {
@@ -377,7 +378,7 @@ export default async function domRunner(
     // We're in dev/watch mode
     createWebpackBundle(
       entryFile,
-      { type, customizeWebpackConfig, plugins, tmpdir },
+      { type, customizeWebpackConfig, plugins, tmpdir, webpack },
       {
         onBuildReady: async (bundleFile) => {
           if (currentBuildPromise) {


### PR DESCRIPTION
As I'm debugging an issue with Next.js@v11, I'm noticing that it's using a custom built webpack. To make it possible to use the custom webpack instance, I'm adding support for a new `webpack` option in .happo.js.