### PR TITLE
Prevent failing gh actions runs when head_commit is missing

### DIFF
--- a/bin/happo-ci-github-actions
+++ b/bin/happo-ci-github-actions
@@ -23,7 +23,7 @@ ENV_VARS=$(echo "
   if (!process.env.CHANGE_URL) {
     if (json.pull_request) {
       console.log(\`export CHANGE_URL=\${json.pull_request.html_url}\`);
-    } else {
+    } else if (json.head_commit) {
       console.log(\`export CHANGE_URL=\${json.head_commit.url}\`);
     }
   }


### PR DESCRIPTION
In some cases, the `head_commit` object is not present in github actions
environments. I don't know exactly when this can happen, but adding a
null-check should help get things resolved. The CHANGE_URL env variable
is optional anyway, so no harm done when it's missing.