### PR TITLE
Fix staticPlugin check

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -8,6 +8,22 @@ import pageRunner from '../pageRunner';
 import remoteRunner from '../remoteRunner';
 import uploadReport from '../uploadReport';
 
+function getStaticPlugin(plugins, config) {
+  const staticPlugin = plugins.find(
+    (plugin) => typeof plugin.generateStaticPackage === 'function',
+  );
+
+  if (staticPlugin) {
+    return staticPlugin;
+  }
+
+  if (config.generateStaticPackage) {
+    return { generateStaticPackage: config.generateStaticPackage };
+  }
+
+  return null;
+}
+
 export default async function runCommand(
   sha,
   config,
@@ -19,9 +35,7 @@ export default async function runCommand(
   rimraf.sync(config.tmpdir);
   fs.mkdirSync(config.tmpdir, { recursive: true });
 
-  const staticPlugin = plugins.find(
-    (plugin) => typeof plugin.generateStaticPackage === 'function',
-  ) || { generateStaticPackage: config.generateStaticPackage };
+  const staticPlugin = getStaticPlugin(plugins, config);
   let result;
   if (pages) {
     result = await pageRunner(config, { isAsync });


### PR DESCRIPTION
The truthiness if staticPlugin is checked to determine if Happo should
use the remoteRunner, but since this is always assigned to an object
now, the logic was broken and Happo would never end up using the
domRunner. I believe we can fix this by being a little more careful
about how we assign the staticPlugin variable.