### PR TITLE
feat: add a `mergeJSDOMOptions` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "engines": {

--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -35,3 +35,4 @@ export function customizeWebpackConfig(config) {
   return config;
 }
 export const webpack = undefined;
+export const jsdomOptions = undefined;

--- a/src/mergeJSDOMOptions.js
+++ b/src/mergeJSDOMOptions.js
@@ -1,0 +1,21 @@
+const isFunction = (value) => typeof value === 'function';
+
+export default (defaultOptions, customOptions = {}) => {
+  const result = { ...defaultOptions };
+
+  Object.entries(customOptions).forEach(([customOptionKey, customOptionValue]) => {
+    const defaultOptionValue = result[customOptionKey];
+    const areBothFunctions = [defaultOptionValue, customOptionValue].every(
+      isFunction,
+    );
+
+    result[customOptionKey] = areBothFunctions
+      ? (...args) => {
+          defaultOptionValue(...args);
+          customOptionValue(...args);
+        }
+      : customOptionValue;
+  });
+
+  return result;
+};

--- a/test/mergeJSDOMOptions-test.js
+++ b/test/mergeJSDOMOptions-test.js
@@ -1,0 +1,32 @@
+import mergeJsdomOptions from '../src/mergeJSDOMOptions';
+
+const testObj = {};
+const defaultObj = {};
+const customObj = {};
+
+const defaultOptions = {
+  modifyTestObj: obj => { obj.default = 'default'; },
+  string: 'default-string',
+  nonOverridenString: 'non overriden string',
+  obj: defaultObj,
+};
+
+const customOptions = {
+  modifyTestObj: obj => { obj.custom = 'custom'; },
+  string: 'custom-string',
+  obj: customObj,
+  nullish: null,
+};
+
+it('correctly merges 2 jsdom options objects', () => {
+  const merged = mergeJsdomOptions(defaultOptions, customOptions);
+
+  merged.modifyTestObj(testObj);
+
+  expect(merged.string).toEqual(customOptions.string);
+  expect(merged.nonOverridenString).toEqual(defaultOptions.nonOverridenString);
+  expect(testObj.default).toEqual('default');
+  expect(testObj.custom).toEqual('custom');
+  expect(merged.obj).toEqual(customObj);
+  expect(merged.nullish).toEqual(null);
+});


### PR DESCRIPTION
Hello! In our setup, I need to provide a `beforeParse` jsDOM option to provide a missing browser API. However, this function would override the function that is declared by default in `JSDOMProvider`. 

In this PR:
- I create a function `mergeJsdomOptions` which is almost like an `Object.assign`, but it doesn't override functions. Instead, it calls both provided functions, first default, then the one configured by the user.
- I add a test for that function
- I add `jsdomOptions` to the `DEFAULTS` file because it was throwing a warning, even though it processed `jsdomOptions`
- I bump a minor version because I don't think that my PR is fixing a bug