### PR TITLE
Export HAPPO_IS_ASYNC in happo-ci

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -13,6 +13,9 @@ HAPPO_SKIP_START_JOB=${HAPPO_SKIP_START_JOB:-}
 HAPPO_GIT_COMMAND=${HAPPO_GIT_COMMAND:-git}
 HAPPO_COMMAND=${HAPPO_COMMAND:-"node_modules/happo.io/build/cli.js"}
 
+# Make HAPPO_IS_ASYNC available to sub commands (`happo run`, `happo compare`)
+export HAPPO_IS_ASYNC
+
 # Make sure we use the full commit shas
 if [ -n "$PREVIOUS_SHA" ] && [ ${#PREVIOUS_SHA} -ne 40 ]; then
   PREVIOUS_SHA="$(${HAPPO_GIT_COMMAND} rev-parse "$PREVIOUS_SHA")"


### PR DESCRIPTION
I've had a report from a customer where the happo-ci flow is running
in async (HAPPO_IS_ASYNC=true) mode but the inner commands (happo run,
happo compare) are triggered in non-async mode. I think this is because
the HAPPO_IS_ASYNC variable isn't exported from the parent script.
Granted, the export isn't needed in most shell environments (my tests
show that it's enough to set it in the parent in bash and sh on Mac).
Exporting it makes the dependency clearer though, and is likely to fix
issues in certain shell environments.