### PR TITLE
Fix requiring react-dom in entry point on windows

### DIFF
--- a/src/createDynamicEntryPoint.js
+++ b/src/createDynamicEntryPoint.js
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import requireRelative from 'require-relative';
-
 import findTestFiles from './findTestFiles';
 
 const { VERBOSE = 'false' } = process.env;
@@ -53,7 +51,7 @@ export default async function createDynamicEntryPoint({
     'window.snaps = {};',
   ];
   if (type === 'react') {
-    const pathToReactDom = requireRelative.resolve('react-dom', process.cwd());
+    const pathToReactDom = require.resolve('react-dom');
     const pathToRW = renderWrapperModule || require.resolve('./renderWrapperReact');
     strings.push(
       `let renderWrapper = require('${pathToRW}');`,


### PR DESCRIPTION
I'm chasing a bug in windows environments where this error shows up:

Module not found: Error: Can't resolve C:some-folderreact-domindex.js

I think this is because requireRelative.resolve doesn't work on Windows.

The require-relative module isn't really needed here (and I question if
we need it elsewhere as well). The commit that added it was
6af271e15e and it doesn't mention require-relative as a hard
requirement. From what I can tell, we might as well use
require.resolve().