### PR TITLE
Allow .happo.js config to be free from happo.io import

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -1,14 +1,13 @@
-const RemoteBrowserTarget = require('./build/RemoteBrowserTarget').default;
-
 module.exports = {
-  pages: [
-    { url: 'https://beteendelabbet.se/', title: 'Beteendelabbet' },
-  ],
+  apiKey: process.env.HAPPO_API_KEY,
+  apiSecret: process.env.HAPPO_API_SECRET,
+  pages: [{ url: 'https://beteendelabbet.se/', title: 'Beteendelabbet' }],
   targets: {
-    'chrome-large': new RemoteBrowserTarget('chrome', {
+    'chrome-large': {
+      browserType: 'chrome',
       viewport: '800x600',
       chunks: 2,
       maxHeight: 10000,
-    }),
+    },
   },
 };

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -10,6 +10,7 @@ import constructReport from './constructReport';
 import createDynamicEntryPoint from './createDynamicEntryPoint';
 import createStaticPackage from './createStaticPackage';
 import createWebpackBundle from './createWebpackBundle';
+import ensureTarget from './ensureTarget';
 import loadCSSFile from './loadCSSFile';
 import makeRequest from './makeRequest';
 import prepareAssetsPackage from './prepareAssetsPackage';
@@ -19,7 +20,15 @@ const knownAssetPackagePaths = {};
 
 const { VERBOSE = 'false' } = process.env;
 
-async function uploadAssets({ apiKey, apiSecret, endpoint, hash, buffer, logger, project }) {
+async function uploadAssets({
+  apiKey,
+  apiSecret,
+  endpoint,
+  hash,
+  buffer,
+  logger,
+  project,
+}) {
   try {
     const assetsDataRes = await makeRequest(
       {
@@ -30,7 +39,9 @@ async function uploadAssets({ apiKey, apiSecret, endpoint, hash, buffer, logger,
       { apiKey, apiSecret },
     );
     logger.info(
-      `${logTag(project)}Reusing existing assets at ${assetsDataRes.path} (previously uploaded on ${assetsDataRes.uploadedAt})`,
+      `${logTag(project)}Reusing existing assets at ${
+        assetsDataRes.path
+      } (previously uploaded on ${assetsDataRes.uploadedAt})`,
     );
     return assetsDataRes.path;
   } catch (e) {
@@ -119,7 +130,7 @@ async function executeTargetWithPrerender({
     logTargetResults({ name, globalCSS, snapPayloads, project });
   }
 
-  const result = await targets[name].execute({
+  const result = await ensureTarget(targets[name]).execute({
     asyncResults: isAsync,
     targetName: name,
     assetsPackage,

--- a/src/ensureTarget.js
+++ b/src/ensureTarget.js
@@ -1,0 +1,8 @@
+import RemoteBrowserTarget from './RemoteBrowserTarget';
+
+export default function ensureTarget(targetOrObject) {
+  if (typeof targetOrObject.execute === 'function') {
+    return targetOrObject;
+  }
+  return new RemoteBrowserTarget(targetOrObject.browserType, targetOrObject);
+}

--- a/src/pageRunner.js
+++ b/src/pageRunner.js
@@ -1,5 +1,6 @@
 import Logger, { logTag } from './Logger';
 import constructReport from './constructReport';
+import ensureTarget from './ensureTarget';
 
 export default async function pagesRunner(
   { apiKey, apiSecret, endpoint, targets, pages, project },
@@ -16,7 +17,7 @@ export default async function pagesRunner(
     const results = await Promise.all(
       targetNames.map(async (name) => {
         const startTime = Date.now();
-        const result = await targets[name].execute({
+        const result = await ensureTarget(targets[name]).execute({
           targetName: name,
           asyncResults: isAsync,
           pages,

--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
 import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import Archiver from 'archiver';
 
@@ -9,6 +9,7 @@ import { FILE_CREATION_DATE } from './createStaticPackage';
 import Logger, { logTag } from './Logger';
 import constructReport from './constructReport';
 import createHash from './createHash';
+import ensureTarget from './ensureTarget';
 import loadCSSFile from './loadCSSFile';
 import makeRequest from './makeRequest';
 
@@ -138,7 +139,7 @@ export default async function remoteRunner(
     const results = await Promise.all(
       targetNames.map(async (name) => {
         const startTime = Date.now();
-        const result = await targets[name].execute({
+        const result = await ensureTarget(targets[name]).execute({
           targetName: name,
           asyncResults: isAsync,
           staticPackage: staticPackagePath,


### PR DESCRIPTION
When running happo via npx, there's little need to install happo
locally. But since the .happo.js config needs to import
RemoteBrowserTarget to work, npx run was hard to do. We can fix this by
dynamically creating the RemoteBrowserTarget instances when we need
them (if they aren't already real targets). The `browserType` option
will specify what browser to use.