### PR TITLE
Add support for extends in pages config items

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -49,7 +49,7 @@ export default async function runCommand(
     logger.start(`${logTag(project)}Creating async report for ${sha}...`);
     const allRequestIds = [];
     result.forEach((item) => allRequestIds.push(...item.result));
-    const { id } = await makeRequest(
+    const response = await makeRequest(
       {
         url: `${endpoint}/api/async-reports/${sha}`,
         method: 'POST',
@@ -63,9 +63,10 @@ export default async function runCommand(
       },
       { endpoint, apiKey, apiSecret, retryCount: 3 },
     );
+    const { id, url } = response;
 
     logger.success();
-    logger.info(`${logTag(project)}Async report id: ${id}`);
+    logger.info(`${logTag(project)}Async report (id=${id}): ${url}`);
   } else {
     logger.start(`${logTag(project)}Uploading report for ${sha}...`);
     const { url } = await uploadReport({

--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -88,6 +88,46 @@ describe('#execute', () => {
     });
   });
 
+  describe('with pages', () => {
+    it('sends the right requests', async () => {
+      const target = subject();
+      const result = await target.execute({
+        pages: [
+          { url: 'http://google.com', title: 'Google' },
+          { title: 'google 2', extends: 'foobar' },
+          { title: 'google 3', extends: 'barfoo' },
+        ],
+        apiKey: 'foobar',
+        apiSecret: 'p@assword',
+        endpoint: 'http://localhost',
+      });
+
+      expect(result).toEqual([
+        { component: 'foobar', snapRequestId: 44 },
+        { component: 'foobar', snapRequestId: 44 },
+        { component: 'foobar', snapRequestId: 44 },
+      ]);
+
+      expect(makeRequest.mock.calls.length).toBe(6);
+
+      const payload = JSON.parse(
+        makeRequest.mock.calls[0][0].formData.payload.value,
+      );
+      expect(payload.pages).toEqual([{ title: 'Google', url: 'http://google.com' }]);
+      const payload2 = JSON.parse(
+        makeRequest.mock.calls[2][0].formData.payload.value,
+      );
+      expect(payload2.pages).toEqual([{ title: 'google 2', extends: 'foobar' }]);
+      expect(payload2.extendsSha).toEqual('foobar');
+
+      const payload3 = JSON.parse(
+        makeRequest.mock.calls[4][0].formData.payload.value,
+      );
+      expect(payload3.pages).toEqual([{ title: 'google 3', extends: 'barfoo' }]);
+      expect(payload3.extendsSha).toEqual('barfoo');
+    });
+  });
+
   describe('when chunks is equal to two', () => {
     beforeEach(() => {
       chunks = 2;


### PR DESCRIPTION
Add support for extends in pages config items
This is a new feature for people on the full-page integration. Instead
of providing urls for all pages, they can provide `extends: <sha>` to
have the snapshot injected from a different report.

https://docs.happo.io/docs/full-page