### PR TITLE
fix(comparison)-config-key-validation

### DIFF
--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -29,6 +29,7 @@ export const renderWrapperModule = undefined;
 export const githubApiUrl = 'https://api.github.com';
 export const compareThreshold = undefined;
 export const generateStaticPackage = undefined;
+export const afterSyncComparison = undefined;
 export const pages = undefined;
 export function customizeWebpackConfig(config) {
   // provide a default no-op for this config option so that we can assume it's


### PR DESCRIPTION
Fix `Unknown config key used in .happo.js: "afterSyncComparison"` warning when passed `afterSyncComparison` configuration