### PR TITLE
Fix fetch timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@babel/preset-react": "^7.12.1",
+    "abort-controller": "^3.0.0",
     "archiver": "^5.0.2",
     "async-retry": "^1.3.1",
     "babel-plugin-dynamic-import-node": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "node-fetch": "^2.6.6",
     "parse-srcset": "^1.0.2",
     "pngjs": "^3.4.0",
-    "prettier": "^2.2.0",
     "require-relative": "^0.8.7",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
@@ -100,6 +99,7 @@
     "http-server": "^0.12.0",
     "jest": "^27.4.5",
     "multiparty": "^4.2.2",
+    "prettier": "^2.2.0",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "webpack": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,13 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -2769,6 +2776,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^4.0.0:
   version "4.0.7"


### PR DESCRIPTION
With the change from request-promise-native to node-fetch, we changed request timeouts (they're now shorter). Some test suites are running into timeouts from the asset upload fetch call. By increasing the timeout we hope to unbreak these test suites. 