### PR TITLE
Add identifiable query param to snap-requests POST

### DIFF
--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -124,7 +124,7 @@ export default class RemoteBrowserTarget {
       }
       return makeRequest(
         {
-          url: `${endpoint}/api/snap-requests`,
+          url: `${endpoint}/api/snap-requests?payloadHash=${payloadHash}`,
           method: 'POST',
           json: true,
           formData,


### PR DESCRIPTION
I'm doing this so that it's easier to grep logs when I need to do debugging.