### PR TITLE
Add timeout waiting for `onBundleReady`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "8.3.3",
+  "version": "8.4.0-alpha",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "engines": {

--- a/src/JSDOMDomProvider.js
+++ b/src/JSDOMDomProvider.js
@@ -55,8 +55,15 @@ export default class JSDOMDomProvider {
   }
 
   async init({ targetName }) {
-    await new Promise((resolve) => {
-      this.dom.window.onBundleReady = resolve;
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() =>
+        reject(new Error('Failed to load Happo bundle within 10s. Check console log for errors.')),
+      10000);
+
+      this.dom.window.onBundleReady = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
     });
     return this.dom.window.happoProcessor.init({ targetName });
   }

--- a/test/integrations/error-test.js
+++ b/test/integrations/error-test.js
@@ -151,17 +151,19 @@ describe('with generated examples that fail to initialize', () => {
     config.type = 'react';
   });
 
-  xdescribe('with the puppeteer plugin', () => {
-    beforeEach(() => {
-      config.plugins = [happoPluginPuppeteer()];
-    });
-
-    it('logs an error', async () => {
+  it('throws a timeout error', async () => {
+    try {
       await subject();
-      expect(console.log.mock.calls.length).toBe(1);
-      expect(console.log.mock.calls[0][0]).toEqual(
-        'Uncaught ReferenceError: foo is not defined',
+    } catch (e) {
+      expect(e.message).toMatch(
+        /Failed to load Happo bundle within/,
       );
-    });
+      expect(console.error.mock.calls[1][0]).toMatch(/foo is not defined/);
+      return;
+    }
+
+
+    // If we end up here, something is wrong
+    expect(false).toBe(true);
   });
 });


### PR DESCRIPTION
I'm trying to fix a silent crash/exit coming from loading the bundle. Before I get to the juicy parts, I want to make sure we don't stall forever waiting for onBundleReady.