### PR TITLE
Increase bundle timeout to 60s, make it configurable

### DIFF
--- a/test/integrations/error-test.js
+++ b/test/integrations/error-test.js
@@ -155,13 +155,10 @@ describe('with generated examples that fail to initialize', () => {
     try {
       await subject();
     } catch (e) {
-      expect(e.message).toMatch(
-        /Failed to load Happo bundle within/,
-      );
+      expect(e.message).toMatch(/Failed to load Happo bundle within/);
       expect(console.error.mock.calls[1][0]).toMatch(/foo is not defined/);
       return;
     }
-
 
     // If we end up here, something is wrong
     expect(false).toBe(true);

--- a/test/jestSetup.js
+++ b/test/jestSetup.js
@@ -1,3 +1,4 @@
 jest.setTimeout(10000);
 delete process.env.HAPPO_API_KEY;
 delete process.env.HAPPO_API_SECRET;
+process.env.HAPPO_BUNDLE_LOAD_TIMEOUT_MS = '10000';


### PR DESCRIPTION
At Airbnb, 10s was not enough. Making the default longer and allowing people to change it using an environment variable should be enough to unblock things.