### PR TITLE
Give webpack time to write bundle file before callback

### DIFF
--- a/src/createWebpackBundle.js
+++ b/src/createWebpackBundle.js
@@ -96,7 +96,10 @@ export default async function createWebpackBundle(
         stats.compilation.errors.forEach((e) => new Logger().error(e));
       } else if (hash !== stats.hash) {
         hash = stats.hash;
-        onBuildReady(bundleFilePath);
+
+        // Call the timeout on next tick to allow webpack to fully write the
+        // bundle to the bundleFilePath
+        setTimeout(() => onBuildReady(bundleFilePath));
       }
     });
     return;


### PR DESCRIPTION
From the report:

webpack calls this callback without actually waiting for the bundle to be written disk, and jsdom winds up reading a partially-written file. adding a setTimeout in there “fixes” it.