### PR TITLE
Add data-happo-ignore to root element

### DIFF
--- a/src/browser/processor.js
+++ b/src/browser/processor.js
@@ -36,6 +36,7 @@ async function renderExample(exampleRenderFunc, { component, variant }) {
   document.body.innerHTML = '';
   const rootElement = document.createElement('div');
   rootElement.setAttribute('id', ROOT_ELEMENT_ID);
+  rootElement.setAttribute('data-happo-ignore', ROOT_ELEMENT_ID);
   document.body.appendChild(rootElement);
 
   const renderInDom = (renderResult) =>

--- a/src/browser/processor.js
+++ b/src/browser/processor.js
@@ -36,7 +36,7 @@ async function renderExample(exampleRenderFunc, { component, variant }) {
   document.body.innerHTML = '';
   const rootElement = document.createElement('div');
   rootElement.setAttribute('id', ROOT_ELEMENT_ID);
-  rootElement.setAttribute('data-happo-ignore', ROOT_ELEMENT_ID);
+  rootElement.setAttribute('data-happo-ignore', 'true');
   document.body.appendChild(rootElement);
 
   const renderInDom = (renderResult) =>

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -150,7 +150,7 @@ it('produces the right html', async () => {
       component: 'Foo-react',
       css: '',
       html:
-        '<div id="happo-root"><div>Outside portal</div></div><div>Inside portal</div>',
+        '<div id="happo-root" data-happo-ignore="true"><div>Outside portal</div></div><div>Inside portal</div>',
       variant: 'innerPortal',
     },
     {


### PR DESCRIPTION
This will cause it to be excluded from the rectangle calculation when used with prerender:false.

When migrating one of my projects from prerender:true to prerender:false I noticed that there was an extra rectangle around smaller examples. Turns out the root element was causing this. In a prerender:true world, we grab the innerHTML of this root node so it isn't present in rendering on Happo workers.