### PR TITLE
Introduce happo.init for remote render

### DIFF
--- a/src/browser/processor.js
+++ b/src/browser/processor.js
@@ -72,12 +72,14 @@ export default class Processor {
     this.cursor = -1;
   }
 
-  init({ targetName } = {}) {
+  init({ targetName, only, chunk } = {}) {
     // validate examples before we start rendering
     this.flattenedExamples = validateAndFilterExamples(
       this.flattenedUnfilteredExamples,
       {
         targetName,
+        only,
+        chunk,
       },
     );
   }
@@ -141,9 +143,8 @@ export default class Processor {
   }
 
   async processCurrent() {
-    const { component, fileName, variant, render } = this.flattenedExamples[
-      this.cursor
-    ];
+    const { component, fileName, variant, render } =
+      this.flattenedExamples[this.cursor];
     const exampleRenderFunc = getRenderFunc(render);
     window.happoCleanup();
     try {

--- a/src/browser/remoteRenderer.js
+++ b/src/browser/remoteRenderer.js
@@ -1,9 +1,10 @@
 window.happo = window.happo || {};
 
-window.happo.initChunk = () => {};
 window.happo.nextExample = () => {
   if (!window.happoProcessor.next()) {
     return Promise.resolve(undefined);
   }
   return window.happoProcessor.processCurrent();
 };
+
+window.happo.init = (options) => window.happoProcessor.init(options);

--- a/src/browser/validateAndFilterExamples.js
+++ b/src/browser/validateAndFilterExamples.js
@@ -1,8 +1,18 @@
 import getRenderFunc from './getRenderFunc';
 
-export default function validateAndFilterExamples(examples, { targetName }) {
-  return examples
+export default function validateAndFilterExamples(
+  examples,
+  { targetName, only, chunk },
+) {
+  const all = examples
     .map((example) => {
+      if (
+        only &&
+        (only.component !== example.component || only.variant !== example.variant)
+      ) {
+        // Not part of this run
+        return undefined;
+      }
       if (
         example.render &&
         Array.isArray(example.render.targets) &&
@@ -18,12 +28,22 @@ export default function validateAndFilterExamples(examples, { targetName }) {
           return undefined;
         }
         throw new Error(
-          `Variant ${example.variant} in component ${
-            example.component
-          } has no render function\nFound in ${example.fileName}`,
+          `Variant ${example.variant} in component ${example.component} has no render function\nFound in ${example.fileName}`,
         );
       }
       return example;
     })
     .filter(Boolean);
+
+  if (only) {
+    // Don't apply chunk filtering if rendering a single example.
+    return all;
+  }
+  if (!chunk) {
+    return all;
+  }
+  const examplesPerChunk = Math.ceil(all.length / chunk.total);
+  const startIndex = chunk.index * examplesPerChunk;
+  const endIndex = startIndex + examplesPerChunk;
+  return all.slice(startIndex, endIndex);
 }

--- a/test/browser/validateAndFilterExamples-test.js
+++ b/test/browser/validateAndFilterExamples-test.js
@@ -3,11 +3,14 @@ import validateAndFilterExamples from '../../src/browser/validateAndFilterExampl
 let subject;
 let examples;
 let targetName;
+let only;
+let chunk;
 
 beforeEach(() => {
   examples = [];
   targetName = 'chrome';
-  subject = () => validateAndFilterExamples(examples, { targetName });
+  only = undefined;
+  subject = () => validateAndFilterExamples(examples, { targetName, only, chunk });
 });
 
 describe('with an empty list', () => {
@@ -75,5 +78,75 @@ describe('when an example has opted out of the target', () => {
 
   it('excludes that example', () => {
     expect(subject()).toEqual([]);
+  });
+});
+
+describe('with an only option', () => {
+  beforeEach(() => {
+    only = { component: 'bar', variant: 'default' };
+    examples = [
+      {
+        component: 'foo',
+        variant: 'default',
+        fileName: './foo-happo.js',
+        render: {
+          render: () => 'foobar',
+        },
+      },
+      {
+        component: 'bar',
+        variant: 'default',
+        fileName: './foo-happo.js',
+        render: {
+          render: () => 'foobar',
+        },
+      },
+    ];
+  });
+
+  it('excludes that example', () => {
+    expect(subject().length).toBe(1);
+    expect(subject()[0].component).toEqual('bar');
+  });
+});
+
+describe('with a chunk option', () => {
+  beforeEach(() => {
+    chunk = { total: 3, index: 1 };
+    examples = [
+      {
+        component: 'foo',
+        variant: 'default',
+        fileName: './foo-happo.js',
+        render: {
+          render: () => 'foobar',
+        },
+      },
+      {
+        component: 'bar',
+        variant: 'default',
+        fileName: './foo-happo.js',
+        render: {
+          render: () => 'foobar',
+        },
+      },
+      {
+        component: 'baz',
+        variant: 'default',
+        fileName: './foo-happo.js',
+        render: {
+          render: () => 'foobar',
+        },
+      },
+    ];
+  });
+
+  it('selects a subset of examples', () => {
+    expect(subject().length).toBe(1);
+    expect(subject()[0].component).toEqual('bar');
+
+    chunk.index = 0;
+    expect(subject().length).toBe(1);
+    expect(subject()[0].component).toEqual('foo');
   });
 });


### PR DESCRIPTION
Also, make sure that chunk information is honored.

happoProcessor.init has been deprecated for a while, but remote rendered builds have still used it. I'm adding the happo.init function instead and at the same time making sure that we honor chunk information.