### PR TITLE
feat: support default file as .cjs

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.22.cjs

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "bin": {
     "happo": "./build/cli.js",
-    "happo-ci-travis": "./bin/happo-ci-travis",
+    "happo-ci": "./bin/happo-ci",
+    "happo-ci-azure-pipelines": "./bin/happo-ci-azure-pipelines",
     "happo-ci-circleci": "./bin/happo-ci-circleci",
     "happo-ci-github-actions": "./bin/happo-ci-github-actions",
-    "happo-ci-azure-pipelines": "./bin/happo-ci-azure-pipelines",
-    "happo-ci": "./bin/happo-ci"
+    "happo-ci-travis": "./bin/happo-ci-travis"
   },
   "scripts": {
     "update-toc": "./scripts/gh-md-toc --insert README.md",
@@ -107,5 +107,6 @@
   "peerDependencies": {
     "babel-loader": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "webpack": "^3.5.5 || ^4.0.0 || ^5.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/src/DEFAULTS.js
+++ b/src/DEFAULTS.js
@@ -19,7 +19,7 @@ export const targets = {
   }),
 };
 export const asyncTimeout = 200;
-export const configFile = './.happo.js';
+export const configFilename = '.happo';
 export const type = 'react';
 export const plugins = [];
 export const prerender = true;

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -1,6 +1,5 @@
 import commander from 'commander';
 
-import { configFile } from './DEFAULTS';
 import Logger from './Logger';
 import compareReportsCommand from './commands/compareReports';
 import devCommand from './commands/dev';
@@ -23,7 +22,7 @@ const HAPPO_IS_ASYNC = RAW_HAPPO_IS_ASYNC === 'true';
 
 commander
   .version(packageJson.version)
-  .option('-c, --config <path>', 'set config path', configFile)
+  .option('-c, --config <path>', 'set config path')
   .option('-o, --only <component>', 'limit to one component')
   .option('-l, --link <url>', 'provide a link back to the commit')
   .option('-a, --async', 'process reports/comparisons asynchronously')

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -6,21 +6,12 @@ import WrappedError from './WrappedError';
 import * as defaultConfig from './DEFAULTS';
 
 async function load(pathToConfigFile) {
-  try {
-    let userConfig = requireRelative(pathToConfigFile, process.cwd());
-    // await if the config is a function, async or not
-    if (typeof userConfig === 'function') {
-      userConfig = await userConfig();
-    }
-    return { ...defaultConfig, ...userConfig };
-  } catch (e) {
-    // We only check for the default config file here, so that a missing custom
-    // config path isn't ignored.
-    if (e.message && /Cannot find.*\.happo\.js/.test(e.message)) {
-      return defaultConfig;
-    }
-    throw new Error(e);
+  let userConfig = requireRelative(pathToConfigFile, process.cwd());
+  // await if the config is a function, async or not
+  if (typeof userConfig === 'function') {
+    userConfig = await userConfig();
   }
+  return { ...defaultConfig, ...userConfig };
 }
 
 async function getPullRequestSecret({ endpoint }, prUrl) {
@@ -31,7 +22,9 @@ async function getPullRequestSecret({ endpoint }, prUrl) {
   });
 
   if (!res.ok) {
-    throw new Error(`Failed to get pull request secret: ${res.status} - ${await res.text()}`);
+    throw new Error(
+      `Failed to get pull request secret: ${res.status} - ${await res.text()}`,
+    );
   }
   const { secret } = await res.json();
   return secret;
@@ -51,12 +44,41 @@ function resolvePRLink(env = process.env) {
 
 export default async function loadUserConfig(pathToConfigFile, env = process.env) {
   const { CHANGE_URL, HAPPO_CONFIG_FILE } = env;
+  let config;
 
   if (HAPPO_CONFIG_FILE) {
     pathToConfigFile = HAPPO_CONFIG_FILE;
   }
 
-  const config = await load(pathToConfigFile);
+  // if provided path, attempt to load config. otherwise, attempt to load
+  // config from default file (in either .js or .cjs).
+  if (pathToConfigFile) {
+    config = await load(pathToConfigFile);
+  } else {
+    const defaultFilePaths = ['js', 'cjs'].map(
+      (ext) => `./${defaultConfig.configFilename}.${ext}`,
+    );
+    for (const filePath of defaultFilePaths) {
+      try {
+        config = await load(filePath);
+
+        if (config != null) {
+          break;
+        }
+      } catch (e) {
+        // Throw error if not a "Cannot find" type
+        if (!e.message || !/Cannot find.*\.happo\.c?js/.test(e.message)) {
+          throw new Error(`Unable to load config from ${filePath}: ${e.message}`);
+        }
+      }
+    }
+
+    // No default file found so use the default config
+    if (config == null) {
+      config = { ...defaultConfig };
+    }
+  }
+
   if (!config.apiKey || !config.apiSecret) {
     const prUrl = CHANGE_URL || resolvePRLink(env);
     if (!prUrl) {


### PR DESCRIPTION
This PR updates happo.io to be able to load the default config filename with either a `cjs` or `js` extension.

- replace DEFAULTS `configFile` with `configFilename`
- remove default config argument from cli commands
- simplify `load` function to not catch errors
- update `loadUserConfig` function to load a provided config path with no catch
- update `loadUserConfig` function to attempt to load the default config file for both `js` and `cjs` extensions (ignoring `Cannot find` error type if thrown), falling back to default config if none found
- yarn version explicitly set (allows project to work as intended in yarn v2+ environments)