### PR TITLE
Fix passing in --fallbackShas

### DIFF
--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -28,8 +28,8 @@ commander
   .option('-l, --link <url>', 'provide a link back to the commit')
   .option('-a, --async', 'process reports/comparisons asynchronously')
   .option(
-    '--fallbackShas',
-    'comma-separated list of fallback shas for compare calls',
+    '--fallbackShas <shas>',
+    'space-, newline- or comma-separated list of fallback shas for compare calls',
   )
   .option(
     '-n, --notify <emails>',

--- a/test/commands/compareReports-test.js
+++ b/test/commands/compareReports-test.js
@@ -95,6 +95,30 @@ describe('when `fallbackShas` is set', () => {
   });
 });
 
+describe('when `fallbackShas` is a space-separated list', () => {
+  it('sends that param to the happo api', async () => {
+    cliArgs.fallbackShas = 'foo bar car';
+    await subject();
+    expect(makeRequest.mock.calls[1][0].body.fallbackShas).toEqual([
+      'foo',
+      'bar',
+      'car',
+    ]);
+  });
+});
+
+describe('when `fallbackShas` is a newline-separated list', () => {
+  it('sends that param to the happo api', async () => {
+    cliArgs.fallbackShas = 'foo\nbar\ncar';
+    await subject();
+    expect(makeRequest.mock.calls[1][0].body.fallbackShas).toEqual([
+      'foo',
+      'bar',
+      'car',
+    ]);
+  });
+});
+
 describe('when fetchPng fails', () => {
   beforeEach(() => {
     fetchPng.mockImplementation(() => Promise.reject(new Error('mocked')));


### PR DESCRIPTION
This arg was treated as a flag as opposed to an argument with a value. Fixed that and added some tests around that. Also made it clearer that fallback shas can be passed as a newline or space separated list as well.