### PR TITLE
Warn instead of failing when asset check fails

### DIFF
--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -94,7 +94,13 @@ async function uploadStaticPackage({
     return assetsDataRes.path;
   } catch (e) {
     if (e.statusCode !== 404) {
-      throw e;
+      logger.warn(
+        `${logTag(
+          project,
+        )}Assuming assets don't exist since we got error response: ${
+          e.statusCode
+        } - ${e.message} - ${e.stack}`,
+      );
     }
   }
 

--- a/src/uploadAssets.js
+++ b/src/uploadAssets.js
@@ -1,0 +1,54 @@
+import { logTag } from './Logger';
+import makeRequest from './makeRequest';
+
+export default async function uploadAssets(
+  streamOrBuffer,
+  { hash, endpoint, apiKey, apiSecret, logger, project },
+) {
+  try {
+    // Check if the assets already exist. If so, we don't have to upload them.
+    const assetsDataRes = await makeRequest(
+      {
+        url: `${endpoint}/api/snap-requests/assets-data/${hash}`,
+        method: 'GET',
+        json: true,
+      },
+      { apiKey, apiSecret },
+    );
+    logger.info(
+      `${logTag(project)}Reusing existing assets at ${
+        assetsDataRes.path
+      } (previously uploaded on ${assetsDataRes.uploadedAt})`,
+    );
+    return assetsDataRes.path;
+  } catch (e) {
+    if (e.statusCode !== 404) {
+      logger.warn(
+        `${logTag(
+          project,
+        )}Assuming assets don't exist since we got error response: ${
+          e.statusCode
+        } - ${e.message} - ${e.stack}`,
+      );
+    }
+  }
+
+  const assetsRes = await makeRequest(
+    {
+      url: `${endpoint}/api/snap-requests/assets/${hash}`,
+      method: 'POST',
+      json: true,
+      formData: {
+        payload: {
+          options: {
+            filename: 'payload.zip',
+            contentType: 'application/zip',
+          },
+          value: streamOrBuffer,
+        },
+      },
+    },
+    { apiKey, apiSecret, retryCount: 2 },
+  );
+  return assetsRes.path;
+}


### PR DESCRIPTION
Sometimes we get network errors when making requests. Most endpoints are retried but the assets-data check is only performed once. When it fails with a non-404 response, the execution halts. We can improve this by instead assuming the assets are not there and continue as if we had a
404. I've added a warning log just to make sure we surface this issue.