### PR TITLE
Change package.json engines field from node 12 to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "bin": {
     "happo": "./build/cli.js",


### PR DESCRIPTION
In https://github.com/happo/happo.io/pull/276 we replaced the jsonwebtoken package with jose, which uses syntax that does not work on node 14 or earlier. I think it might be worthwhile to make this compatibility a little more explicit in our engines field.