### PR TITLE
Fix invalid version command in happo-ci

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -41,7 +41,7 @@ echo "HAPPO_FALLBACK_SHAS_COUNT: ${HAPPO_FALLBACK_SHAS_COUNT}"
 echo "Using Node version: $(node -v)"
 
 set +e
-HAPPO_VERSION=$("$HAPPO_COMMAND" version)
+HAPPO_VERSION=$("$HAPPO_COMMAND" --version)
 if [ $? -eq 0 ]; then
   echo "Using happo CLI version: ${HAPPO_VERSION}"
 else

--- a/test/cli-mock.js
+++ b/test/cli-mock.js
@@ -26,7 +26,7 @@ if (/compare fail bar/.test(cmd)) {
   process.exit(1);
 }
 
-if (/version/.test(cmd)) {
+if (/--version/.test(cmd)) {
   console.log('v0.0.999');
   process.exit(0);
 }

--- a/test/happo-ci-test.js
+++ b/test/happo-ci-test.js
@@ -94,7 +94,7 @@ describe('when CURRENT_SHA and PREVIOUS_SHA is the same', () => {
   it('runs a single report', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'version',
+      '--version',
       'run bar --link http://foo.bar/ --message Commit message',
     ]);
     expect(getGitLog()).toEqual([
@@ -110,7 +110,7 @@ describe('when there is a report for PREVIOUS_SHA', () => {
   it('runs the right happo commands', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'version',
+      '--version',
       'start-job foo bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
@@ -133,7 +133,7 @@ describe('when there is a report for PREVIOUS_SHA', () => {
     it('runs the right happo commands', () => {
       subject();
       expect(getCliLog()).toEqual([
-        'version',
+        '--version',
         'start-job foo bar --link http://foo.bar/ --message Commit message',
         'run bar --link http://foo.bar/ --message Commit message',
         'has-report foo',
@@ -159,7 +159,7 @@ describe('when there is a report for PREVIOUS_SHA', () => {
     it('runs the right happo commands', () => {
       subject();
       expect(getCliLog()).toEqual([
-        'version',
+        '--version',
         'run bar --link http://foo.bar/ --message Commit message',
         'compare foo bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
       ]);
@@ -234,7 +234,7 @@ describe('when there is no report for PREVIOUS_SHA', () => {
   it('does not checkout anything, runs a single report', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'version',
+      '--version',
       'start-job no-report bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'compare no-report bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
@@ -256,7 +256,7 @@ describe('when there is no report for PREVIOUS_SHA', () => {
     it('runs the right happo commands', () => {
       subject();
       expect(getCliLog()).toEqual([
-        'version',
+        '--version',
         'start-job no-report bar --link http://foo.bar/ --message Commit message',
         'run bar --link http://foo.bar/ --message Commit message',
         'has-report no-report',
@@ -288,7 +288,7 @@ describe('when the compare call fails', () => {
   it('fails the script', () => {
     expect(subject).toThrow();
     expect(getCliLog()).toEqual([
-      'version',
+      '--version',
       'start-job fail bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'compare fail bar --link http://foo.bar/ --message Commit message --author Tom Dooner <tom@dooner.com>',
@@ -313,7 +313,7 @@ describe('when happo.io is not installed for the PREVIOUS_SHA and HAPPO_IS_ASYNC
   it('runs the right happo commands', () => {
     subject();
     expect(getCliLog()).toEqual([
-      'version',
+      '--version',
       'start-job no-happo bar --link http://foo.bar/ --message Commit message',
       'run bar --link http://foo.bar/ --message Commit message',
       'has-report no-happo',


### PR DESCRIPTION
I made a mistake when adding this call earlier. Unfortunately tests didn't catch it because they are using a mock.