### PR TITLE
Update actions/checkout and actions/setup-node from v2 to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   node16:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test using Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: yarn install --frozen-lockfile --ignore-engines
@@ -22,9 +22,9 @@ jobs:
   node18:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test using Node.js 18.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile --ignore-engines
@@ -33,9 +33,9 @@ jobs:
   node20:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test using Node.js 20.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
       - run: yarn install --frozen-lockfile --ignore-engines
@@ -44,9 +44,9 @@ jobs:
   node22:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test using Node.js 22.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - run: yarn install --frozen-lockfile --ignore-engines


### PR DESCRIPTION
This resolves some warnings related to the node version these actions are using.