### PR TITLE
Change master to main for github workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run Unit tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   node16:


### PR DESCRIPTION
I believe that this will enable us to change the default branch in this repo from master to main.

Just before this merges we will update the default branch in this repo from master to main.