### PR TITLE
Listen to close instead of finish when making static zips

### DIFF
--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -31,7 +31,7 @@ function staticDirToZipFile(dir) {
       entries.push(entry);
     });
 
-    output.on('finish', async () => {
+    output.on('close', async () => {
       validateArchive(archive.pointer(), entries);
       resolve(pathToZipFile);
     });


### PR DESCRIPTION
We have been investigating an error where zip files that are produced from this code end up being corrupt when we try to unzip them. It seems that since we are using a file here that we might want to listen to the close event instead of the finish event, since close will wait until the file handle is closed. I think that if we resolve a little too early that we might end up sometimes uploading zip files that are not fully written to disk.

I also noticed that in other places where we are creating zip files that we do not use a file on disk to write them to, and instead we write to a buffer that we eventually upload. In these cases it probably works fine and actually makes sense to use the finish event. It might be worth revisiting how this works and potentially refactor it to use that pattern instead.