### PR TITLE
Default to branch named "main"

### DIFF
--- a/bin/happo-ci-circleci
+++ b/bin/happo-ci-circleci
@@ -3,7 +3,7 @@
 # Make the whole script fail on errors
 set -euo pipefail
 
-BASE_BRANCH=${BASE_BRANCH:-"origin/master"}
+BASE_BRANCH=${BASE_BRANCH:-"origin/main"}
 echo "Using ${BASE_BRANCH} as the default branch (change this with the BASE_BRANCH environment variable)"
 PREVIOUS_SHA=$(git merge-base "${BASE_BRANCH}" "${CIRCLE_SHA1}")
 

--- a/bin/happo-ci-travis
+++ b/bin/happo-ci-travis
@@ -3,12 +3,12 @@
 # Make the whole script fail on errors
 set -eou pipefail
 
-BASE_BRANCH=${BASE_BRANCH:-"master"}
+BASE_BRANCH=${BASE_BRANCH:-"main"}
 echo "Using ${BASE_BRANCH} as the default branch (change this with the BASE_BRANCH environment variable)"
 
 if [ ! -z "${TRAVIS_COMMIT_RANGE:-}" ]; then
   # The PREVIOUS_SHA will be equal to the commit that the PR is based on (which
-  # is usually some commit on the master branch), or the commit that the last
+  # is usually some commit on the main branch), or the commit that the last
   # build was triggered for. Travis gives us a range of commits. We need the
   # first one.
   PREVIOUS_SHA="${TRAVIS_COMMIT_RANGE//\.\..*/}"

--- a/test/github_pull_request_event.json
+++ b/test/github_pull_request_event.json
@@ -33,7 +33,7 @@
       "type": "User",
       "site_admin": false
     },
-    "body": "This is a pretty simple change that we need to pull into master.",
+    "body": "This is a pretty simple change that we need to pull into main.",
     "created_at": "2019-05-15T15:20:33Z",
     "updated_at": "2019-05-15T15:20:33Z",
     "closed_at": null,
@@ -166,7 +166,7 @@
         "forks": 0,
         "open_issues": 2,
         "watchers": 0,
-        "default_branch": "master",
+        "default_branch": "main",
         "allow_squash_merge": true,
         "allow_merge_commit": true,
         "allow_rebase_merge": true,
@@ -174,8 +174,8 @@
       }
     },
     "base": {
-      "label": "Codertocat:master",
-      "ref": "master",
+      "label": "Codertocat:main",
+      "ref": "main",
       "sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e",
       "user": {
         "login": "Codertocat",
@@ -289,7 +289,7 @@
         "forks": 0,
         "open_issues": 2,
         "watchers": 0,
-        "default_branch": "master",
+        "default_branch": "main",
         "allow_squash_merge": true,
         "allow_merge_commit": true,
         "allow_rebase_merge": true,
@@ -429,7 +429,7 @@
     "forks": 0,
     "open_issues": 2,
     "watchers": 0,
-    "default_branch": "master"
+    "default_branch": "main"
   },
   "sender": {
     "login": "Codertocat",

--- a/test/github_push_event.json
+++ b/test/github_push_event.json
@@ -106,9 +106,8 @@
     "forks": 1,
     "open_issues": 2,
     "watchers": 0,
-    "default_branch": "master",
-    "stargazers": 0,
-    "master_branch": "master"
+    "default_branch": "main",
+    "stargazers": 0
   },
   "pusher": {
     "name": "Codertocat",


### PR DESCRIPTION
In cases where we can't figure out a baseline commit in our CI scripts, we default to `origin/master`. This was the usual default branch name back in the days, but it has since changed to `origin/main`. I'm making the switch to "main" now.

This is a breaking change but one that is easy to make non-breaking if you use a BASE_BRANCH=origin/master environment variable.