### PR TITLE
Run Jest with `--colors` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 16.x
       - run: yarn install --frozen-lockfile --ignore-engines
       - run: yarn lint
-      - run: yarn test
+      - run: yarn test --colors
 
   node18:
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn test
+      - run: yarn test --colors
 
   node20:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: 20.x
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn test
+      - run: yarn test --colors
 
   node22:
     runs-on: ubuntu-latest
@@ -50,4 +50,4 @@ jobs:
         with:
           node-version: 22.x
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn test
+      - run: yarn test --colors


### PR DESCRIPTION
This improves the readability of the test output in CI.