### PR TITLE
fix: handle ESM-style config file

### DIFF
--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -11,6 +11,9 @@ async function load(pathToConfigFile) {
     // await if the config is a function, async or not
     if (typeof userConfig === 'function') {
       userConfig = await userConfig();
+    } else if (userConfig?.default) {
+      // handle esm
+      userConfig = userConfig.default;
     }
     return { ...defaultConfig, ...userConfig };
   } catch (e) {

--- a/test/loadUserConfig-test.js
+++ b/test/loadUserConfig-test.js
@@ -186,3 +186,22 @@ it('warns when using an unknown config key', async () => {
     'Unknown config key used in .happo.js: "foobar"',
   );
 });
+
+it('handles an ESM-style config', async () => {
+  requireRelative.mockImplementation(() => ({
+    __esModule: true,
+    default: {
+      apiKey: '1',
+      apiSecret: '2',
+      targets: {
+        firefox: new RemoteBrowserTarget('firefox', { viewport: '800x600' }),
+      },
+    },
+  }));
+  const config = await loadUserConfig('bogus', {});
+  expect(config.apiKey).toEqual('1');
+  expect(config.apiSecret).toEqual('2');
+  expect(config.targets).toEqual({
+    firefox: new RemoteBrowserTarget('firefox', { viewport: '800x600' }),
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/happo/happo-e2e/issues/50

Note that this PR doesn't change how the file itself is loaded to completely settle ESM compat, but it at least makes the CLI work properly when used in conjunction with `NODE_OPTIONS='--experimental-require-module'`