### PR TITLE
Use AbortSignal.timeout instead of AbortController in makeRequest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,18 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  node16:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test using Node.js 16.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 16.x
-      - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn lint
-      - run: yarn test --colors
-
   node18:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Unit tests
+name: Test
 
 on:
   push:
@@ -7,35 +7,20 @@ on:
     branches: [main]
 
 jobs:
-  node18:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20, 22]
+    name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
-      - name: Test using Node.js 18.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-      - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn test --colors
 
-  node20:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test using Node.js 20.x
+      - name: Setup Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
-      - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn test --colors
+          node-version: ${{ matrix.node }}
 
-  node22:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test using Node.js 22.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
       - run: yarn install --frozen-lockfile --ignore-engines
+
       - run: yarn test --colors

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "bin": {
     "happo": "./build/cli.js",
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@babel/preset-react": "^7.12.1",
-    "abort-controller": "^3.0.0",
     "archiver": "^7.0.1",
     "async-retry": "^1.3.1",
     "babel-plugin-dynamic-import-node": "^2.1.0",


### PR DESCRIPTION
Just a small refactor to help clean up this code a bit.

`AbortSignal.timeout` is available as of Node 17.3.0, so I am also updating the engines field and removing the Node 16 tests.