### PR TITLE
Avoid passing undefined through to async-retry, remove maxTries option

### DIFF
--- a/src/makeRequest.js
+++ b/src/makeRequest.js
@@ -29,7 +29,6 @@ export default async function makeRequest(
     apiKey,
     apiSecret,
     retryCount = 0,
-    /* legacy */ maxTries,
     timeout = 60000,
     retryMinTimeout,
     retryMaxTimeout,
@@ -38,70 +37,78 @@ export default async function makeRequest(
 ) {
   const { url, method = 'GET', formData, body: jsonBody } = requestAttributes;
 
-  return asyncRetry(
-    async () => {
-      const start = Date.now();
+  const retryOpts = {
+    onRetry: (e) => {
+      console.warn(`Failed ${method} ${url}. Retrying...`);
+      console.warn(e);
+    },
+  };
 
-      // We must avoid reusing FormData instances when retrying requests
-      // because they are consumed and cannot be reused.
-      // More info: https://github.com/node-fetch/node-fetch/issues/1743
-      const body = formData
-        ? prepareFormData(formData)
-        : jsonBody
-          ? JSON.stringify(jsonBody)
-          : undefined;
+  if (retryCount != null) {
+    retryOpts.retries = retryCount;
+  }
+  if (retryMinTimeout != null) {
+    retryOpts.minTimeout = retryMinTimeout;
+  }
+  if (retryMaxTimeout != null) {
+    retryOpts.maxTimeout = retryMaxTimeout;
+  }
 
-      const encodedSecret = new TextEncoder().encode(apiSecret);
-      // https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md
-      const signed = await new SignJWT({ key: apiKey })
-        .setProtectedHeader({ alg: 'HS256', kid: apiKey })
-        .sign(encodedSecret);
+  return asyncRetry(async () => {
+    const start = Date.now();
 
-      const headers = {
-        Authorization: `Bearer ${signed}`,
-        'User-Agent': `happo.io@${version}`,
-      };
+    // We must avoid reusing FormData instances when retrying requests
+    // because they are consumed and cannot be reused.
+    // More info: https://github.com/node-fetch/node-fetch/issues/1743
+    const body = formData
+      ? prepareFormData(formData)
+      : jsonBody
+        ? JSON.stringify(jsonBody)
+        : undefined;
 
-      if (jsonBody) {
-        headers['Content-Type'] = 'application/json';
-      }
+    const encodedSecret = new TextEncoder().encode(apiSecret);
+    // https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md
+    const signed = await new SignJWT({ key: apiKey })
+      .setProtectedHeader({ alg: 'HS256', kid: apiKey })
+      .sign(encodedSecret);
 
-      try {
-        const response = await fetch(url, {
-          headers,
-          compress: true,
-          agent: HTTP_PROXY ? new HttpsProxyAgent(HTTP_PROXY) : undefined,
-          signal: AbortSignal.timeout(timeout),
-          ...requestAttributes,
-          body,
-        });
-        if (!response.ok) {
-          const e = new Error(
-            `Request to ${method} ${url} failed: ${
-              response.status
-            } - ${await response.text()}`,
-          );
-          e.statusCode = response.status;
-          throw e;
-        }
-        const result = await response.json();
-        return result;
-      } catch (e) {
-        if (e.type === 'aborted') {
-          e.message = `Timeout when fetching ${url} using method ${method}`;
-        }
-        e.message = `${e.message} (took ${Date.now() - start} ms)`;
+    const headers = {
+      Authorization: `Bearer ${signed}`,
+      'User-Agent': `happo.io@${version}`,
+    };
+
+    if (jsonBody) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    try {
+      const response = await fetch(url, {
+        headers,
+        compress: true,
+        agent: HTTP_PROXY ? new HttpsProxyAgent(HTTP_PROXY) : undefined,
+        signal: AbortSignal.timeout(timeout),
+        ...requestAttributes,
+        body,
+      });
+
+      if (!response.ok) {
+        const e = new Error(
+          `Request to ${method} ${url} failed: ${
+            response.status
+          } - ${await response.text()}`,
+        );
+        e.statusCode = response.status;
         throw e;
       }
-    },
-    {
-      retries: retryCount || maxTries,
-      minTimeout: retryMinTimeout,
-      maxTimeout: retryMaxTimeout,
-      onRetry: (e) => {
-        console.warn(`Failed ${method} ${url}. Retrying...`);
-        console.warn(e);
-      },
-    },
-  );
+
+      const result = await response.json();
+      return result;
+    } catch (e) {
+      if (e.type === 'aborted') {
+        e.message = `Timeout when fetching ${url} using method ${method}`;
+      }
+      e.message = `${e.message} (took ${Date.now() - start} ms)`;
+      throw e;
+    }
+  }, retryOpts);
 }

--- a/src/makeRequest.js
+++ b/src/makeRequest.js
@@ -54,6 +54,12 @@ export default async function makeRequest(
     retryOpts.maxTimeout = retryMaxTimeout;
   }
 
+  const encodedSecret = new TextEncoder().encode(apiSecret);
+  // https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md
+  const signed = await new SignJWT({ key: apiKey })
+    .setProtectedHeader({ alg: 'HS256', kid: apiKey })
+    .sign(encodedSecret);
+
   return asyncRetry(async () => {
     const start = Date.now();
 
@@ -65,12 +71,6 @@ export default async function makeRequest(
       : jsonBody
         ? JSON.stringify(jsonBody)
         : undefined;
-
-    const encodedSecret = new TextEncoder().encode(apiSecret);
-    // https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md
-    const signed = await new SignJWT({ key: apiKey })
-      .setProtectedHeader({ alg: 'HS256', kid: apiKey })
-      .sign(encodedSecret);
 
     const headers = {
       Authorization: `Bearer ${signed}`,


### PR DESCRIPTION
The makeRequest function accepts some options that default to undefined when they are not specified. These are then passed into async-retry, which eventually gets merged into the default options in a loop like this:

```js
for (var key in options) {
  opts[key] = options[key];
}
```

https://github.com/tim-kos/node-retry/blob/11efd6e4/lib/retry.js#L17-L26

This means that when the options are not specified, they end up overriding the reasonable defaults, which was unintentional.

The result is that since we don't specify these options most of the time, most of the requests will be retried immediately instead of waiting a little bit.

To fix this, we need to construct the options a little more carefully.

I wanted to test this using jest fake timers, but when I did that it caused the tests to stall out and I wasn't able to figure out why in a reasonable amount of time, so instead I decided that it was okay for the test to take a second and just set the number of retries to a low amount.

While I am touching this, I decided to also simplify the API a small amount by removing a really old leacy `maxTries` option.