### PR TITLE
Use zlib level 6 when making zip files

### DIFF
--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -66,6 +66,7 @@ export default function createStaticPackage({ tmpdir, publicFolders }) {
       // Concurrency in the stat queue leads to non-deterministic output.
       // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2253139948
       statConcurrency: 1,
+      zlib: { level: 6 },
     });
 
     const stream = new Writable();

--- a/src/prepareAssetsPackage.js
+++ b/src/prepareAssetsPackage.js
@@ -17,6 +17,7 @@ function makePackage({ paths, publicFolders }) {
       // Concurrency in the stat queue leads to non-deterministic output.
       // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2253139948
       statConcurrency: 1,
+      zlib: { level: 6 },
     });
 
     const stream = new Writable();

--- a/src/remoteRunner.js
+++ b/src/remoteRunner.js
@@ -20,6 +20,7 @@ function staticDirToZipFile(dir) {
       // Concurrency in the stat queue leads to non-deterministic output.
       // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2253139948
       statConcurrency: 1,
+      zlib: { level: 6 },
     });
 
     const rnd = crypto.randomBytes(4).toString('hex');


### PR DESCRIPTION
It seems that by default Archiver uses zlib level 1, which prioritizes compression speed over compression ratio. By default, zlib uses level 6, which is a nice balance between compression speed and compression ratio. In my testing, level 6 does indeed seem to be a sweet spot, and seems to make my test cases about 14% smaller without sacrificing much performance.

Since these zips are immediately uploaded, stored, and downloaded again somewhere else, I am hopeful that this 14% size difference will more than make up for slightly slower compression speeds.