### PR TITLE
Refactor archiving to go through single determinstic function

### DIFF
--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -1,11 +1,4 @@
-import { Writable } from 'stream';
-import crypto from 'crypto';
-import path from 'path';
-import fs from 'fs';
-
-import Archiver from 'archiver';
-
-import validateArchive from './validateArchive';
+import deterministicArchive from './deterministicArchive';
 
 // We're setting the creation date to the same for all files so that the zip
 // packages created for the same content ends up having the same fingerprint.
@@ -24,107 +17,26 @@ const IFRAME_CONTENT = `
 `;
 
 /**
- * Gets all files in a directory and all of its subdirectories
+ * Creates a static package of the given files
  *
- * The returned value is sorted for deterministic output.
- *
- * @param {string} dir
- * @returns {Array<string>}
+ * @param {Object} options
+ * @param {string} options.tmpdir
+ * @param {string[]} options.publicFolders
+ * @returns {Promise<{buffer: Buffer, hash: string}>}
  */
-function getFilesRecursive(dir) {
-  const files = [];
-  const dirs = [dir];
+export default async function createStaticPackage({ tmpdir, publicFolders }) {
+  const cwd = process.cwd();
+  const filteredPublicFolders = publicFolders.filter((folder) =>
+    folder.startsWith(cwd),
+  );
+  const uniqueDirs = Array.from(new Set([tmpdir, ...filteredPublicFolders]));
 
-  while (dirs.length > 0) {
-    const currentDir = dirs.shift();
-    // Node 18 adds `recursive` option to `fs.readdirSync`, which would
-    // make this function simpler.
-    const dirents = fs.readdirSync(currentDir, { withFileTypes: true });
-
-    for (const dirent of dirents) {
-      const res = path.resolve(currentDir, dirent.name);
-
-      if (dirent.isDirectory()) {
-        // This is a directory, so we are going to add it to the list of directories to recurse into.
-        dirs.push(res);
-        files.push(res);
-      } else {
-        files.push(res);
-      }
-    }
-  }
-
-  // Sort the files for deterministic output. This is important so that
-  // the archive hash is the same.
-  files.sort((a, b) => a.localeCompare(b));
-  return files;
-}
-
-export default function createStaticPackage({ tmpdir, publicFolders }) {
-  return new Promise((resolve, reject) => {
-    const archive = new Archiver('zip', {
-      // Concurrency in the stat queue leads to non-deterministic output.
-      // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2253139948
-      statConcurrency: 1,
-      zlib: { level: 6 },
-    });
-
-    const stream = new Writable();
-    const data = [];
-
-    stream._write = (chunk, _enc, done) => {
-      data.push(...chunk);
-      done();
-    };
-
-    const entries = [];
-    archive.on('entry', (entry) => {
-      entries.push(entry);
-    });
-
-    stream.on('finish', () => {
-      validateArchive(archive.pointer(), entries);
-      const buffer = Buffer.from(data);
-      const hash = crypto.createHash('md5').update(buffer).digest('hex');
-
-      resolve({ buffer, hash });
-    });
-    archive.pipe(stream);
-
-    // We can't use archive.directory() here because it is not deterministic.
-    // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2252938075
-    const tmpdirFiles = getFilesRecursive(tmpdir);
-    for (const file of tmpdirFiles) {
-      archive.file(file, {
-        name: file.slice(tmpdir.length + 1),
-        prefix: '',
-        date: FILE_CREATION_DATE,
-      });
-    }
-
-    publicFolders.forEach((folder) => {
-      if (folder === tmpdir) {
-        // ignore, since this is handled separately
-      } else if (folder.startsWith(process.cwd())) {
-        const folderFiles = getFilesRecursive(folder);
-        for (const file of folderFiles) {
-          archive.file(file, {
-            name: file.slice(folder.length + 1),
-            prefix: '',
-            date: FILE_CREATION_DATE,
-          });
-        }
-      }
-    });
-
-    archive.append(IFRAME_CONTENT, {
+  return deterministicArchive(uniqueDirs, [
+    {
       name: 'iframe.html',
-      date: FILE_CREATION_DATE,
-    });
-
-    archive.on('error', reject);
-    archive.finalize();
-  });
+      content: IFRAME_CONTENT,
+    },
+  ]);
 }
 
 export { FILE_CREATION_DATE };

--- a/src/deterministicArchive.js
+++ b/src/deterministicArchive.js
@@ -1,0 +1,143 @@
+import { Writable } from 'stream';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import Archiver from 'archiver';
+
+import validateArchive from './validateArchive';
+
+// We're setting the creation date to the same for all files so that the zip
+// packages created for the same content ends up having the same fingerprint.
+const FILE_CREATION_DATE = new Date('Fri Feb 08 2019 13:31:55 GMT+0100 (CET)');
+
+/**
+ * Resolves all files in a directory and all of its subdirectories
+ *
+ * @param {string} dirOrFile
+ * @returns {Promise<Array<{name: string, path: string}>>}
+ */
+async function resolveFilesRecursiveForDir(dirOrFile) {
+  const isDir = (await fs.promises.lstat(dirOrFile)).isDirectory();
+
+  if (isDir) {
+    const files = await fs.promises.readdir(dirOrFile, {
+      withFileTypes: true,
+      recursive: true,
+    });
+
+    return files
+      .filter((dirent) => dirent.isFile())
+      .map((dirent) => {
+        const fullPath = path.resolve(dirent.path, dirent.name);
+        return {
+          name: fullPath.slice(dirOrFile.length + 1),
+          path: fullPath,
+        };
+      });
+  }
+
+  return [
+    {
+      name: path.basename(dirOrFile),
+      path: path.resolve(dirOrFile),
+    },
+  ];
+}
+
+/**
+ * Resolves all files in all directories recursively
+ *
+ * @param {...string} dirsAndFiles
+ * @returns {Promise<Array<{name: string, path: string}>>}
+ */
+async function resolveFilesRecursive(...dirsAndFiles) {
+  const files = await Promise.all(
+    dirsAndFiles.filter(Boolean).map(resolveFilesRecursiveForDir),
+  );
+
+  return files.flat();
+}
+
+/**
+ * Creates a deterministic archive of the given files
+ *
+ * @param {string[]} dirsAndFiles
+ * @param {{name: string, content: string}[]} contentToArchive
+ * @returns {Promise<{buffer: Buffer, hash: string}>}
+ */
+export default async function deterministicArchive(
+  dirsAndFiles,
+  contentToArchive = [],
+) {
+  const uniqueDirsAndFiles = Array.from(new Set(dirsAndFiles));
+
+  // Sort by name to make the output deterministic
+  const filesToArchiveSorted = (
+    await resolveFilesRecursive(...uniqueDirsAndFiles)
+  ).sort((a, b) => a.name.localeCompare(b.name));
+
+  const contentToArchiveSorted = contentToArchive.sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  return new Promise((resolve, reject) => {
+    const archive = new Archiver('zip', {
+      // Concurrency in the stat queue leads to non-deterministic output.
+      // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2253139948
+      statConcurrency: 1,
+      zlib: { level: 6 },
+    });
+
+    const stream = new Writable();
+    const data = [];
+
+    stream._write = (chunk, _enc, done) => {
+      data.push(...chunk);
+      done();
+    };
+
+    const entries = [];
+    archive.on('entry', (entry) => {
+      entries.push(entry);
+    });
+
+    stream.on('finish', () => {
+      validateArchive(archive.pointer(), entries);
+      const buffer = Buffer.from(data);
+      const hash = crypto.createHash('md5').update(buffer).digest('hex');
+
+      resolve({ buffer, hash });
+    });
+    archive.pipe(stream);
+
+    const seenFiles = new Set();
+
+    // We can't use archive.directory() here because it is not deterministic.
+    // https://github.com/archiverjs/node-archiver/issues/383#issuecomment-2252938075
+    for (const file of filesToArchiveSorted) {
+      if (!seenFiles.has(file.name)) {
+        archive.file(file.path, {
+          name: file.name,
+          prefix: '',
+          date: FILE_CREATION_DATE,
+        });
+        seenFiles.add(file.name);
+      }
+    }
+
+    for (const file of contentToArchiveSorted) {
+      if (!seenFiles.has(file.name)) {
+        archive.append(file.content, {
+          name: file.name,
+          prefix: '',
+          date: FILE_CREATION_DATE,
+        });
+        seenFiles.add(file.name);
+      }
+    }
+
+    archive.on('error', reject);
+    archive.finalize();
+  });
+}

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -110,6 +110,7 @@ async function uploadStaticPackage({
     tmpdir,
     publicFolders,
   });
+
   const assetsPath = await uploadAssets(buffer, {
     apiKey,
     apiSecret,

--- a/test/createStaticPackage-test.js
+++ b/test/createStaticPackage-test.js
@@ -14,7 +14,8 @@ beforeEach(() => {
     'test/integrations/assets', // relative
   ];
   tmpdir = path.resolve(__dirname, 'assets');
-  subject = () => createStaticPackage({
+  subject = () =>
+    createStaticPackage({
       tmpdir,
       publicFolders,
     });
@@ -41,10 +42,99 @@ it('creates deterministic hashes when content has not changed', async () => {
 it('picks out the right files', async () => {
   const { buffer } = await subject();
   const zip = new AdmZip(buffer);
-  expect(
-    zip
-      .getEntries()
-      .map(({ entryName }) => entryName)
-      .includes('solid-white.png'),
-  ).toBeTruthy();
+
+  const entries = zip
+    .getEntries()
+    .map(({ entryName }) => entryName)
+    .filter((entryName) => !entryName.includes('.DS_Store'));
+
+  expect(entries).toContain('iframe.html');
+  expect(entries).not.toContain('one.jpg');
+
+  expect(entries).toEqual([
+    'iframe.html',
+    '.happo-alternate-async.js',
+    '.happo-alternate.js',
+    '000-f7f7f7.png',
+    '000-fff.png',
+    'airbnb.png',
+    'assets/000-f7f7f7.png',
+    'assets/000-fff.png',
+    'assets/airbnb.png',
+    'assets/f7f7f7-aa.png',
+    'assets/ffffff-aa.png',
+    'assets/sample.jpg',
+    'assets/sample.txt',
+    'assets/solid-black.png',
+    'assets/solid-white-120px-wide.png',
+    'assets/solid-white-120px.png',
+    'assets/solid-white.png',
+    'browser/getRenderFunc-test.js',
+    'browser/validateAndFilterExamples-test.js',
+    'check-happo-mock.js',
+    'cli-mock.js',
+    'cli-test.js',
+    'commands/compareReports-test.js',
+    'compareSnapshots-test.js',
+    'createStaticPackage-test.js',
+    'deterministicArchive-test.js',
+    'f7f7f7-aa.png',
+    'fetchPng-test.js',
+    'ffffff-aa.png',
+    'findAssetPaths-test.js',
+    'findCSSAssetPaths-test.js',
+    'getComponentNameFromFileName-test.js',
+    'git-mock.js',
+    'github_pull_request_event.json',
+    'github_push_event.json',
+    'happo-ci-test.js',
+    'inlineResources/1x1.jpg',
+    'inlineResources/1x1.png',
+    'inlineResources/circle.svg',
+    'integrations/assets/one.jpg',
+    'integrations/error-test.js',
+    'integrations/examples/Bar-react-happo.js',
+    'integrations/examples/Button.ffs',
+    'integrations/examples/dynamically-imported.js',
+    'integrations/examples/Foo-error-empty-happo.js',
+    'integrations/examples/Foo-error-generated-happo.js',
+    'integrations/examples/Foo-error-happo.js',
+    'integrations/examples/Foo-error-misconfigured-happo.js',
+    'integrations/examples/Foo-error-syntax-happo.js',
+    'integrations/examples/Foo-error-throws-on-render-happo.js',
+    'integrations/examples/Foo-plain-happo.js',
+    'integrations/examples/Foo-react-happo.js',
+    'integrations/examples/Generated-react-happo.js',
+    'integrations/examples/InlineCSSVariables-plain-happo.js',
+    'integrations/examples/static/1x1.png',
+    'integrations/MockTarget.js',
+    'integrations/one.css',
+    'integrations/plain-test.js',
+    'integrations/plugin-examples.js',
+    'integrations/react-test.js',
+    'integrations/reactSetup.js',
+    'integrations/renderWrapper.js',
+    'integrations/static-files/bundle.js',
+    'integrations/static-files/iframe.html',
+    'integrations/static-plugin-test.js',
+    'integrations/static-test.js',
+    'integrations/styles.css',
+    'integrations/theme.js',
+    'integrations/two.css',
+    'jestSetup.js',
+    'loadUserConfig-test.js',
+    'Logger-test.js',
+    'makeRequest-test.js',
+    'mergeJSDOMOptions-test.js',
+    'postGithubComment-test.js',
+    'prepareAssetsPackage-test.js',
+    'RemoteBrowserTarget-test.js',
+    'sample.jpg',
+    'sample.txt',
+    'solid-black.png',
+    'solid-white-120px-wide.png',
+    'solid-white-120px.png',
+    'solid-white.png',
+    'validateArchive-test.js',
+  ]);
 });

--- a/test/deterministicArchive-test.js
+++ b/test/deterministicArchive-test.js
@@ -1,0 +1,79 @@
+import path from 'path';
+
+import AdmZip from 'adm-zip';
+
+import deterministicArchive from '../src/deterministicArchive';
+
+const publicFolders = [
+  __dirname, // absolute path
+  'test/integrations/assets', // relative
+];
+
+const tmpdir = path.resolve(__dirname, 'assets');
+
+it('creates a package', async () => {
+  const result = await deterministicArchive([tmpdir, ...publicFolders]);
+
+  expect(result.buffer).not.toBe(undefined);
+  expect(result.hash).not.toBe(undefined);
+});
+
+it('creates deterministic hashes when content has not changed', async () => {
+  const promises = Array.from({ length: 20 }).map(() =>
+    deterministicArchive([tmpdir, ...publicFolders]),
+  );
+  const results = await Promise.all(promises);
+  const hashes = results.map(({ hash }) => hash);
+
+  expect(hashes).toHaveLength(20);
+  expect(hashes[0]).not.toBeUndefined();
+  expect(typeof hashes[0]).toBe('string');
+  expect(hashes[0].length).toBeGreaterThan(0);
+  expect(hashes.every((hash) => hash === hashes[0])).toBe(true);
+});
+
+it('picks out the right files', async () => {
+  const { buffer } = await deterministicArchive([tmpdir, ...publicFolders]);
+
+  const zip = new AdmZip(buffer);
+  expect(
+    zip
+      .getEntries()
+      .map(({ entryName }) => entryName)
+      .includes('solid-white.png'),
+  ).toBeTruthy();
+});
+
+it('does not include duplicate files', async () => {
+  const resultNormal = await deterministicArchive([tmpdir, ...publicFolders]);
+  const resultWithPossibleDuplicates = await deterministicArchive([
+    tmpdir,
+    tmpdir,
+    ...publicFolders,
+    ...publicFolders,
+  ]);
+  expect(resultNormal.hash).toEqual(resultWithPossibleDuplicates.hash);
+  expect(resultNormal.buffer).toEqual(resultWithPossibleDuplicates.buffer);
+
+  const zip = new AdmZip(resultWithPossibleDuplicates.buffer);
+  const entries = zip
+    .getEntries()
+    .map(({ entryName }) => entryName)
+    // This file is gitignored, so we want to filter it out to make local and CI
+    // runs consistent.
+    .filter((entryName) => !entryName.includes('.DS_Store'));
+
+  expect(entries).toHaveLength(84);
+});
+
+it('can include in-memory content', async () => {
+  const content = 'hi friends';
+  const result = await deterministicArchive(
+    [tmpdir, ...publicFolders],
+    [{ name: 'my-in-memory-file.txt', content }],
+  );
+
+  const zip = new AdmZip(result.buffer);
+  const myFile = zip.getEntry('my-in-memory-file.txt');
+  expect(myFile.getData().toString()).toBe(content);
+});

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -336,8 +336,6 @@ it('works with prerender=false', async () => {
     'iframe.html',
     'index.html',
     'one.jpg',
-    'static/',
-    'static/media/',
     'static/media/1x1.f9992a90.png',
   ]);
   // require('fs').writeFileSync('staticPackage.zip',


### PR DESCRIPTION
We had three places that were interfacing with the archiver package, and they all need to do basically the same thing--create a deterministic zip file. If the zip file is nondeterministic, then downstream problems with caching will arise. Since creating a deterministic zip requires some special handling, I decided that it would be best to refactor this code to all run through the same function that guarantees a deterministic output.

While working on this I noticed that the remoteRunner was using archiver's directory function, which I believe can by nondeterministic, so this should help to stabilize those zip files.