### PR TITLE
Remove string.prototype.matchall dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "require-relative": "^0.8.7",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "string.prototype.matchall": "^4.0.0",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {

--- a/src/findCSSAssetPaths.js
+++ b/src/findCSSAssetPaths.js
@@ -1,7 +1,5 @@
 import path from 'path';
 
-import matchAll from 'string.prototype.matchall';
-
 import stripQueryStringAndHash from './stripQueryStringAndHash';
 
 const URL_PATTERN = /url\(['"]?(\/?[^)"']+)['"]?\)/g;
@@ -16,7 +14,7 @@ const URL_PATTERN = /url\(['"]?(\/?[^)"']+)['"]?\)/g;
  *   path where we should attempt to locate the file in the filesystem.
  */
 export default function findCSSAssetPaths({ css, source }) {
-  const paths = Array.from(matchAll(css, URL_PATTERN))
+  const paths = Array.from(css.matchAll(URL_PATTERN))
     .map((match) => match[1])
     .filter((url) => !/^http|\/\//.test(url))
     .map(stripQueryStringAndHash);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6600,20 +6600,6 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string.prototype.matchall@^4.0.0:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
-  integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    es-abstract "^1.20.4"
-    get-intrinsic "^1.1.3"
-    has-symbols "^1.0.3"
-    internal-slot "^1.0.3"
-    regexp.prototype.flags "^1.4.3"
-    side-channel "^1.0.4"
-
 string.prototype.matchall@^4.0.12:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz#6c88740e49ad4956b1332a911e949583a275d4c0"


### PR DESCRIPTION
We only use this in Node, and it is available since Node 12. Since we only support Node 18+, it is safe to remove the dependency.