### PR TITLE
Use yarn cache for Jest tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: 'yarn'
 
       - run: yarn install --frozen-lockfile --ignore-engines
 


### PR DESCRIPTION
I added this option when I set up linting in CI, and we might as well use it in our Jest tests to make them faster.