### PR TITLE
Update rimraf v3 to v6 and use node fs.rm in commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "parse-srcset": "^1.0.2",
     "pngjs": "^3.4.0",
     "require-relative": "^0.8.7",
-    "rimraf": "^3.0.0",
+    "rimraf": "^6.0.1",
     "source-map-support": "^0.5.9",
     "supports-color": "^7.1.0"
   },

--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import rimraf from 'rimraf';
 
 import Logger from '../Logger';
 import compareReportsCommand from './compareReports';
@@ -15,8 +14,10 @@ export default async function devCommand(config, { only }) {
   const { apiKey, apiSecret, endpoint, project } = config;
   let baselineSha;
   const logger = new Logger();
-  rimraf.sync(config.tmpdir);
-  fs.mkdirSync(config.tmpdir, { recursive: true });
+
+  await fs.promises.rm(config.tmpdir, { recursive: true, force: true });
+  await fs.promises.mkdir(config.tmpdir, { recursive: true });
+
   domRunner(config, {
     only,
     onReady: async (snaps) => {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import rimraf from 'rimraf';
 
 import Logger, { logTag } from '../Logger';
 import domRunner from '../domRunner';
@@ -32,8 +31,8 @@ export default async function runCommand(
   const logger = new Logger();
   const { apiKey, apiSecret, endpoint, project, plugins, pages } = config;
 
-  rimraf.sync(config.tmpdir);
-  fs.mkdirSync(config.tmpdir, { recursive: true });
+  await fs.promises.rm(config.tmpdir, { recursive: true, force: true });
+  await fs.promises.mkdir(config.tmpdir, { recursive: true });
 
   const staticPlugin = getStaticPlugin(plugins, config);
   let result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,7 +3245,7 @@ glob@^10.0.0:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-glob@^11.0.1:
+glob@^11.0.0, glob@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.1.tgz#1c3aef9a59d680e611b53dcd24bb8639cef064d9"
   integrity sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==
@@ -5189,12 +5189,13 @@ rimraf@^2.6.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+rimraf@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.0.1.tgz#ffb8ad8844dd60332ab15f52bc104bc3ed71ea4e"
+  integrity sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==
   dependencies:
-    glob "^7.1.3"
+    glob "^11.0.0"
+    package-json-from-dist "^1.0.0"
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
We can avoid rimraf in our JS code pretty easily since Node 16 added the recursive option to rm.