### PR TITLE
Update https-proxy-agent v5 to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "commander": "^2.15.1",
     "form-data": "^4.0.0",
     "glob": "^11.0.1",
-    "https-proxy-agent": "^5.0.0",
+    "https-proxy-agent": "^7.0.6",
     "jose": "^5.4.1",
     "jsdom": "^16.4.0",
     "lcs-image-diff": "^3.0.0",

--- a/src/makeRequest.js
+++ b/src/makeRequest.js
@@ -1,5 +1,5 @@
 import FormData from 'form-data';
-import HttpsProxyAgent from 'https-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import asyncRetry from 'async-retry';
 import fetch from 'node-fetch';
 import { SignJWT } from 'jose';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,6 +1758,11 @@ agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+agent-base@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
+  integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
+
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
@@ -3438,6 +3443,14 @@ https-proxy-agent@^5.0.0:
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
     debug "4"
 
 human-signals@^2.1.0:


### PR DESCRIPTION
The main breaking change is in v6, which changes the signature of the constructor.

https://github.com/TooTallNate/proxy-agents/blob/main/packages/https-proxy-agent/CHANGELOG.md#600

Looking at our usage, I don't think we need to do anything special to adjust for this.