### PR TITLE
Move rimraf to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "parse-srcset": "^1.0.2",
     "pngjs": "^7.0.0",
     "require-relative": "^0.8.7",
-    "rimraf": "^6.0.1",
     "source-map-support": "^0.5.9",
     "supports-color": "^7.1.0"
   },
@@ -97,6 +96,7 @@
     "prettier": "^3.5.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
+    "rimraf": "^6.0.1",
     "webpack": "^5.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
We only use this to clear out the build directory locally.