### PR TITLE
Sort files in findTestFiles

### DIFF
--- a/src/findTestFiles.js
+++ b/src/findTestFiles.js
@@ -4,5 +4,7 @@ export default async function findTestFiles(pattern) {
   const files = await glob(pattern, {
     ignore: ['**/node_modules/**', '**/dist/**', '**/build/**'],
   });
-  return files;
+
+  // Sort the files to make the output deterministic.
+  return files.sort((a, b) => a.localeCompare(b));
 }


### PR DESCRIPTION
After updating the glob package and trying out happo.io@v12.0.0-beta.1, I noticed that there were some diffs that I hadn't expected. After some investigation I noticed that the order of some of the test files in the generated happo-entry.js file changed, which I think may have been triggered by the changes in findTestFiles and the glob package update.

I am hoping to stabilize this by sorting the files.