### PR TITLE
Dowgrade glob v11 to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-plugin-dynamic-import-node": "^2.1.0",
     "commander": "^2.15.1",
     "form-data": "^4.0.0",
-    "glob": "^11.0.1",
+    "glob": "^10.0.0",
     "https-proxy-agent": "^7.0.6",
     "jose": "^5.4.1",
     "jsdom": "^16.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,7 +3272,7 @@ glob@^10.0.0:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-glob@^11.0.0, glob@^11.0.1:
+glob@^11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.1.tgz#1c3aef9a59d680e611b53dcd24bb8639cef064d9"
   integrity sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==


### PR DESCRIPTION
The only change listed in the v11 changelog is dropping support for node before v20. We want to support node v18 right now, so I am downgrading this back to v10.

https://github.com/isaacs/node-glob/blob/main/changelog.md#110