### PR TITLE
Install production dependencies with engines check in CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
-      - run: yarn install --frozen-lockfile --ignore-engines
+      - name: Install dependencies
+        run: |
+          yarn install --frozen-lockfile --production=true
+          yarn install --frozen-lockfile --ignore-engines
 
       - run: yarn test --colors
 


### PR DESCRIPTION
We recently updated glob to v11, which does not support Node 18, and so have to downgrade it and publish another release:

https://github.com/happo/happo.io/pull/330

I want to make sure we catch this in CI next time and I think this might do the trick.