### PR TITLE
Fix recursing to find files in Node <18.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: ['18.16.0', 20, 22]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4

--- a/src/deterministicArchive.js
+++ b/src/deterministicArchive.js
@@ -2,8 +2,8 @@ import { Writable } from 'stream';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { glob } from 'glob';
 
+import { glob } from 'glob';
 import Archiver from 'archiver';
 
 import validateArchive from './validateArchive';
@@ -23,14 +23,12 @@ async function resolveFilesRecursiveForDir(dirOrFile) {
   const isDir = (await fs.promises.lstat(resolvedDirOrFile)).isDirectory();
 
   if (isDir) {
-    const files = Array.from(
-      await glob.sync('**/*', {
-        cwd: resolvedDirOrFile,
-        nodir: true,
-        absolute: true,
-        dot: true,
-      }),
-    );
+    const files = await glob('**/*', {
+      cwd: resolvedDirOrFile,
+      nodir: true,
+      absolute: true,
+      dot: true,
+    });
 
     return files.map((fullPath) => {
       return {


### PR DESCRIPTION
The `path` and `parentPath` properties of a Dirent object isn't available until 18.17 and 18.20 respectively. To make our package compatible again with older Node versions, I'm switching out `fs.readdir` for `glob`.