### PR TITLE
Add Buffer | ReadableStream to determinsticArchive arg type

### DIFF
--- a/src/deterministicArchive.js
+++ b/src/deterministicArchive.js
@@ -64,7 +64,7 @@ async function resolveFilesRecursive(...dirsAndFiles) {
  * Creates a deterministic archive of the given files
  *
  * @param {string[]} dirsAndFiles
- * @param {{name: string, content: string}[]} contentToArchive
+ * @param {{name: string, content: string | Buffer | ReadableStream}[]} contentToArchive
  * @returns {Promise<{buffer: Buffer, hash: string}>}
  */
 export default async function deterministicArchive(


### PR DESCRIPTION
We don't use these types for anything yet, so this is just for our own reference purposes.

This argument is passed through to archiver, which can accept these types.