### PR TITLE
Keep dir structure for single files in deterministicArchive

### DIFF
--- a/src/deterministicArchive.js
+++ b/src/deterministicArchive.js
@@ -40,7 +40,7 @@ async function resolveFilesRecursiveForDir(dirOrFile) {
 
   return [
     {
-      name: path.basename(resolvedDirOrFile),
+      name: path.relative(process.cwd(), resolvedDirOrFile),
       stream: fs.createReadStream(resolvedDirOrFile),
     },
   ];

--- a/test/deterministicArchive-test.js
+++ b/test/deterministicArchive-test.js
@@ -91,3 +91,33 @@ it('handles relative paths', async () => {
 
   expect(entries).toEqual(['one.jpg']);
 });
+
+it('keeps folder structure when adding single files', async () => {
+  const result = await deterministicArchive(['test/integrations/assets/one.jpg']);
+  const zip = new AdmZip(result.buffer);
+
+  const entries = zip
+    .getEntries()
+    .map(({ entryName }) => entryName)
+    // This file is gitignored, so we want to filter it out to make local and CI
+    // runs consistent.
+    .filter((entryName) => !entryName.includes('.DS_Store'));
+
+  expect(entries).toEqual(['test/integrations/assets/one.jpg']);
+});
+
+it('keeps folder structure when adding single files with absolute paths', async () => {
+  const result = await deterministicArchive([
+    path.resolve(__dirname, './integrations/assets/one.jpg'),
+  ]);
+  const zip = new AdmZip(result.buffer);
+
+  const entries = zip
+    .getEntries()
+    .map(({ entryName }) => entryName)
+    // This file is gitignored, so we want to filter it out to make local and CI
+    // runs consistent.
+    .filter((entryName) => !entryName.includes('.DS_Store'));
+
+  expect(entries).toEqual(['test/integrations/assets/one.jpg']);
+});


### PR DESCRIPTION
I found an issue with happo-cypress and inlined canvas images. Basically, the canvas element is converted to an image and inserted into the page, plus added to the asset package for the happo-cypress run. In old versions of the asset packages, the inlined canvas image would be kept in a `.happo-tmp/inlined/<hash>.png` file. In recent versions, the file is instead stored directly in the root of the asset package, `./<hash>.png`.

In happo-e2e, this commit introduce the bug to happo-cypress: https://github.com/happo/happo-e2e/commit/1cfe6ffbcb88ca638728918226dfbb632cc97866 (Use deterministicArchive.js from main happo.io library)

By keeping the directory structure, these entries will be stored in the right folder, so that the image elements will reference the right thing:

`<img src=".happo-tmp/_inlined/<hash>.png">`