### PR TITLE
Delete old comments as part of posting new one

### DIFF
--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -135,7 +135,10 @@ commander
       isAsync,
       fallbackShas,
     });
-    if (commander.link && process.env.HAPPO_GITHUB_USER_CREDENTIALS) {
+    if (
+      commander.link &&
+      (process.env.HAPPO_GITHUB_USER_CREDENTIALS || process.env.HAPPO_GITHUB_TOKEN)
+    ) {
       await postGithubComment({
         link: commander.link,
         statusImageUrl: result.statusImageUrl,

--- a/src/postGithubComment.js
+++ b/src/postGithubComment.js
@@ -5,7 +5,58 @@ import Logger from './Logger';
 const REPO_URL_MATCHER = /https?:\/\/[^/]+\/([^/]+)\/([^/]+)\/pull\/([0-9]+)/;
 // https://github.com/lightstep/lightstep/pull/6555
 
-const { HAPPO_GITHUB_USER_CREDENTIALS, HAPPO_GITHUB_TOKEN } = process.env;
+const {
+  HAPPO_GITHUB_USER_CREDENTIALS,
+  HAPPO_GITHUB_TOKEN,
+  HAPPO_DELETE_OLD_COMMENTS,
+} = process.env;
+
+const HAPPO_COMMENT_MARKER = '<!-- happo-comment -->';
+
+async function deleteExistingComments({
+  normalizedGithubApiUrl,
+  owner,
+  repo,
+  prNumber,
+  authHeader,
+}) {
+  const commentsRes = await fetch(
+    `${normalizedGithubApiUrl}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+    {
+      headers: {
+        'User-Agent': 'happo.io client',
+        Authorization: authHeader,
+      },
+      method: 'GET',
+    },
+  );
+
+  if (!commentsRes.ok) {
+    throw new Error(
+      `Failed to fetch existing comments: ${commentsRes.status} ${await commentsRes.text()}`,
+    );
+  }
+
+  const comments = await commentsRes.json();
+  const happoComments = comments.filter((comment) =>
+    comment.body.startsWith(HAPPO_COMMENT_MARKER),
+  );
+
+  await Promise.all(
+    happoComments.map((comment) =>
+      fetch(
+        `${normalizedGithubApiUrl}/repos/${owner}/${repo}/issues/${prNumber}/comments/${comment.id}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'User-Agent': 'happo.io client',
+            Authorization: authHeader,
+          },
+        },
+      ),
+    ),
+  );
+}
 
 export default async function postGithubComment({
   statusImageUrl,
@@ -14,6 +65,7 @@ export default async function postGithubComment({
   githubApiUrl,
   legacyUserCredentials = HAPPO_GITHUB_USER_CREDENTIALS,
   authToken = HAPPO_GITHUB_TOKEN,
+  deleteOldComments = HAPPO_DELETE_OLD_COMMENTS === 'true',
 }) {
   const matches = link.match(REPO_URL_MATCHER);
   if (!matches) {
@@ -33,6 +85,9 @@ export default async function postGithubComment({
   if (authToken) {
     authHeader = `Bearer ${authToken}`;
   } else if (legacyUserCredentials) {
+    new Logger().warn(
+      'HAPPO_GITHUB_USER_CREDENTIALS is deprecated and will be removed in a future version. Use HAPPO_GITHUB_TOKEN instead.',
+    );
     const [user, pass] = legacyUserCredentials.split(':');
     authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
   } else {
@@ -41,7 +96,17 @@ export default async function postGithubComment({
     );
   }
 
-  const body = `[![Happo status](${statusImageUrl})](${compareUrl})`;
+  if (deleteOldComments) {
+    await deleteExistingComments({
+      normalizedGithubApiUrl,
+      owner,
+      repo,
+      prNumber,
+      authHeader,
+    });
+  }
+
+  const body = `${HAPPO_COMMENT_MARKER}\n[![Happo status](${statusImageUrl})](${compareUrl})`;
   const res = await fetch(
     `${normalizedGithubApiUrl}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
     {
@@ -59,5 +124,6 @@ export default async function postGithubComment({
       `Failed to post github comment: ${res.status} ${await res.text()}`,
     );
   }
+
   return true;
 }

--- a/test/postGithubComment-test.js
+++ b/test/postGithubComment-test.js
@@ -11,11 +11,14 @@ let statusImageUrl;
 let legacyUserCredentials;
 let authToken;
 let link;
+let deleteOldComments;
 
 beforeEach(() => {
+  deleteOldComments = false;
   fetch.mockReset();
   fetch.mockImplementation(() => ({
     ok: true,
+    json: () => Promise.resolve([]),
   }));
   githubApiUrl = 'https://api.ghe.com';
   compareUrl = 'https://foo.bar/foo/bar';
@@ -31,43 +34,89 @@ beforeEach(() => {
       githubApiUrl,
       legacyUserCredentials,
       authToken,
+      deleteOldComments,
     });
 });
 
-it('posts a comment', async () => {
+it('posts a new comment', async () => {
   await subject();
-  const url = fetch.mock.calls[0][0];
-  const { headers, body, method } = fetch.mock.calls[0][1];
-  expect(url).toEqual(
+
+  const [
+    postCommentUrl,
+    {
+      headers: postCommentHeaders,
+      method: postCommentMethod,
+      body: postCommentBody,
+    },
+  ] = fetch.mock.calls[0];
+  expect(postCommentUrl).toEqual(
     'https://api.ghe.com/repos/happo/happo-view/issues/156/comments',
   );
-  expect(body).toEqual(
-    JSON.stringify({
-      body: '[![Happo status](https://foo.bar/foo/bar/status.svg)](https://foo.bar/foo/bar)',
-    }),
+
+  expect(postCommentBody).toEqual(
+    '{"body":"<!-- happo-comment -->\\n[![Happo status](https://foo.bar/foo/bar/status.svg)](https://foo.bar/foo/bar)"}',
   );
-  expect(headers).toEqual({
+  expect(postCommentHeaders).toEqual({
     Authorization: 'Bearer baz',
     'User-Agent': 'happo.io client',
   });
-  expect(method).toEqual('POST');
+  expect(postCommentMethod).toEqual('POST');
 });
 
 it('returns true', async () => {
   expect(await subject()).toBe(true);
 });
 
-describe('when githubApiUrl ends with a slash', () => {
+describe('when there are old comments', () => {
   beforeEach(() => {
-    githubApiUrl = 'https://ghe.com/api/v3/';
+    deleteOldComments = true;
+    fetch.mockImplementation(() => ({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 1,
+            body: 'foo', // should not be deleted
+          },
+          {
+            id: 2,
+            body: '<!-- happo-comment --> foo bar', // should be deleted
+          },
+          {
+            id: 3,
+            body: 'foo <!-- happo-comment -->', // should not be deleted since the marker is not at the beginning of the line
+          },
+        ]),
+    }));
   });
 
-  it('constructs a correct URL', async () => {
+  it('deletes the ones matching the marker', async () => {
     await subject();
-    const url = fetch.mock.calls[0][0];
-    expect(url).toEqual(
-      'https://ghe.com/api/v3/repos/happo/happo-view/issues/156/comments',
+    const [
+      deleteCommentUrl,
+      { headers: deleteCommentHeaders, method: deleteCommentMethod },
+    ] = fetch.mock.calls[1];
+    expect(deleteCommentUrl).toEqual(
+      'https://api.ghe.com/repos/happo/happo-view/issues/156/comments/2',
     );
+    expect(deleteCommentHeaders).toEqual({
+      Authorization: 'Bearer baz',
+      'User-Agent': 'happo.io client',
+    });
+    expect(deleteCommentMethod).toEqual('DELETE');
+
+    const [
+      postCommentUrl,
+      { headers: postCommentHeaders, method: postCommentMethod },
+    ] = fetch.mock.calls[2];
+    expect(postCommentUrl).toEqual(
+      'https://api.ghe.com/repos/happo/happo-view/issues/156/comments',
+    );
+    expect(postCommentHeaders).toEqual({
+      Authorization: 'Bearer baz',
+      'User-Agent': 'happo.io client',
+    });
+    expect(postCommentMethod).toEqual('POST');
   });
 });
 
@@ -96,7 +145,7 @@ describe('when no auth token is provided', () => {
   });
 });
 
-describe('when a legacy user credentials are provided', () => {
+describe('when legacy user credentials are provided', () => {
   beforeEach(() => {
     legacyUserCredentials = 'foo:bar';
   });


### PR DESCRIPTION
This is on a request from a customer. They are using comment posting and noticed that the list of comments grow quite long on a PR, especially when you are pushing a lot of changes to it. We can make this better by removing all old comments before posting our new one.

To make sure that only Happo comments are removed I'm adding a marker at the top of each comment (html comment) that we will use to make sure we only remove relevant comments.

This new behavior is opt-in and is only active when HAPPO_DELETE_OLD_COMMENTS="true"