### PR TITLE
Export HAPPO_FALLBACK_SHAS from happo-ci

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -27,6 +27,9 @@ fi
 HAPPO_FALLBACK_SHAS_COUNT=${HAPPO_FALLBACK_SHAS_COUNT:-50}
 HAPPO_FALLBACK_SHAS=${HAPPO_FALLBACK_SHAS:-$(${HAPPO_GIT_COMMAND} log --format=%H --first-parent --max-count=${HAPPO_FALLBACK_SHAS_COUNT} "$PREVIOUS_SHA"^ || true)}
 
+# Make HAPPO_FALLBACK_SHAS available to sub commands (`happo compare`)
+export HAPPO_FALLBACK_SHAS
+
 echo "Using the following ENV variables:"
 echo "PREVIOUS_SHA: ${PREVIOUS_SHA}"
 echo "CURRENT_SHA: ${CURRENT_SHA}"


### PR DESCRIPTION
We noticed that this env var was not being exported, so it was not available to the happo compare script. This means that slower and more expensive database lookups need to happen since the list of fallback SHAs from git are not available to determine the baseline report SHAs.