### PR TITLE
Add lang="en" attribute to html element in iframe.html

### DIFF
--- a/src/createStaticPackage.js
+++ b/src/createStaticPackage.js
@@ -6,8 +6,9 @@ const FILE_CREATION_DATE = new Date('Fri Feb 08 2019 13:31:55 GMT+0100 (CET)');
 
 const IFRAME_CONTENT = `
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <title>Happo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>

--- a/test/integrations/static-files/iframe.html
+++ b/test/integrations/static-files/iframe.html
@@ -1,5 +1,7 @@
-<html>
+<html lang="en">
   <head>
+    <meta charset="UTF-8" />
+    <title>Happo</title>
     <script src="/bundle.js"></script>
   </head>
   <body></body>


### PR DESCRIPTION
This file is used for Happo Examples with `prerender: false`. To make this document less likely to violate accessibility guidelines, I'm adding a lang attribute and a title element.