### PR TITLE
Include `axeResults` in constructed reports

### DIFF
--- a/src/constructReport.js
+++ b/src/constructReport.js
@@ -1,17 +1,20 @@
 export default async function constructReport(results) {
   const report = [];
   results.forEach(({ name: target, result }) => {
-    result.forEach(({ component, variant, url, width, height, snapRequestId }) => {
-      report.push({
-        component,
-        variant,
-        url,
-        width,
-        height,
-        target,
-        snapRequestId,
-      });
-    });
+    result.forEach(
+      ({ component, variant, url, width, height, axeResults, snapRequestId }) => {
+        report.push({
+          component,
+          variant,
+          url,
+          width,
+          height,
+          target,
+          snapRequestId,
+          axeResults,
+        });
+      },
+    );
   });
 
   return report;


### PR DESCRIPTION
I'm working on a change to include axe results in Happo reports. This information needs to be passed along with the report in order to get Happo to use them.