### PR TITLE
Use git to determine previous SHA in GitHub actions

### DIFF
--- a/bin/happo-ci-github-actions
+++ b/bin/happo-ci-github-actions
@@ -5,14 +5,23 @@ set -euo pipefail
 
 # Prepare environment variables found in the github event json file.
 ENV_VARS=$(echo "
+  const { execSync } = require('child_process');
   const json = require('$GITHUB_EVENT_PATH');
+
   if (!process.env.PREVIOUS_SHA) {
+    let baseRef;
+
     if (json.pull_request) {
-      console.log(\`export PREVIOUS_SHA=\${json.pull_request.base.sha}\`);
+      baseRef = json.pull_request.base.ref;
     } else {
-      console.log(\`export PREVIOUS_SHA=\${json.before}\`);
+      // fallback to default branch
+      baseRef = process.env.BASE_BRANCH || 'origin/main';
     }
+
+    const mergeBase = execSync(\`git merge-base origin/\${baseRef} HEAD\`).toString().trim();
+    console.log(\`export PREVIOUS_SHA=\${mergeBase}\`);
   }
+
   if (!process.env.CURRENT_SHA) {
     if (json.pull_request) {
       console.log(\`export CURRENT_SHA=\${json.pull_request.head.sha}\`);
@@ -20,6 +29,7 @@ ENV_VARS=$(echo "
       console.log(\`export CURRENT_SHA=\${json.after}\`);
     }
   }
+
   if (!process.env.CHANGE_URL) {
     if (json.pull_request) {
       console.log(\`export CHANGE_URL=\${json.pull_request.html_url}\`);


### PR DESCRIPTION

I've noticed that we often end up using the wrong report for comparisons
on GitHub actions. I think this is because the event JSON gives us
`pull_request.base.sha` as the tip of the base branch and not the merge
base SHA.

To make this work better, I think we want to use `git merge-base`. This
is similar to what we do in the CircleCI integration.

