### PR TITLE
Revert changes from 12.4.1 and 12.4.2

### DIFF
--- a/bin/happo-ci-github-actions
+++ b/bin/happo-ci-github-actions
@@ -5,23 +5,14 @@ set -euo pipefail
 
 # Prepare environment variables found in the github event json file.
 ENV_VARS=$(echo "
-  const { execSync } = require('child_process');
   const json = require('$GITHUB_EVENT_PATH');
-
   if (!process.env.PREVIOUS_SHA) {
-    let baseBranch;
-
     if (json.pull_request) {
-      baseBranch = \`origin/\${json.pull_request.base.ref}\`;
+      console.log(\`export PREVIOUS_SHA=\${json.pull_request.base.sha}\`);
     } else {
-      // fallback to default branch
-      baseBranch = process.env.BASE_BRANCH || 'origin/main';
+      console.log(\`export PREVIOUS_SHA=\${json.before}\`);
     }
-
-    const mergeBase = execSync(\`git merge-base \${baseBranch} HEAD\`).toString().trim();
-    console.log(\`export PREVIOUS_SHA=\${mergeBase}\`);
   }
-
   if (!process.env.CURRENT_SHA) {
     if (json.pull_request) {
       console.log(\`export CURRENT_SHA=\${json.pull_request.head.sha}\`);
@@ -29,7 +20,6 @@ ENV_VARS=$(echo "
       console.log(\`export CURRENT_SHA=\${json.after}\`);
     }
   }
-
   if (!process.env.CHANGE_URL) {
     if (json.pull_request) {
       console.log(\`export CHANGE_URL=\${json.pull_request.html_url}\`);


### PR DESCRIPTION
These changes ended up being accidentally breaking changes, so I'm reverting so I can publish a new patch version without the changes, and then revert them again and publish as a major version bump to help reduce friction and potential confusion for folks who are trying to get updated.

This makes the code identical to v12.4.0 now.