### PR TITLE
Update Jest matchers for Jest v30

### DIFF
--- a/test/RemoteBrowserTarget-test.js
+++ b/test/RemoteBrowserTarget-test.js
@@ -24,13 +24,13 @@ it('does not fail', () => {
 
 it('validates viewports', () => {
   viewport = '400x500px';
-  expect(subject).toThrowError(/Invalid viewport "400x500px"/);
+  expect(subject).toThrow(/Invalid viewport "400x500px"/);
 });
 
 it('finds viewports that cause issues for internet explorer', () => {
   viewport = '316x500';
   browserName = 'edge';
-  expect(subject).toThrowError(
+  expect(subject).toThrow(
     'Invalid viewport width for the "edge" target (you provided 316). Smallest width it can handle is 400.',
   );
 });

--- a/test/commands/compareReports-test.js
+++ b/test/commands/compareReports-test.js
@@ -354,7 +354,7 @@ describe('when `afterSyncComparison` is set', () => {
     cliArgs.isAsync = false;
     await subject();
     expect(afterSyncComparisonMock).toHaveBeenCalledTimes(1);
-    expect(afterSyncComparisonMock).toBeCalledWith(compareResult);
+    expect(afterSyncComparisonMock).toHaveBeenCalledWith(compareResult);
   });
 
   it("and isAsync is enabled and compareThreshold is defined, afterSyncComparison shouldn't be run", async () => {
@@ -368,7 +368,7 @@ describe('when `afterSyncComparison` is set', () => {
     cliArgs.isAsync = false;
     await subject();
     expect(afterSyncComparisonMock).toHaveBeenCalledTimes(1);
-    expect(afterSyncComparisonMock).toBeCalledWith(compareResult);
+    expect(afterSyncComparisonMock).toHaveBeenCalledWith(compareResult);
   });
 
   it("and isAsync is enabled and compareThreshold is not defined, afterSyncComparison shouldn't be run", async () => {


### PR DESCRIPTION
The new version dropped a couple of matchers we were using here.