### PR TITLE
Tell dependabot to group babel-jest with jest updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
         patterns:
           - '@babel/*'
           - 'babel*'
+        exclude-patterns:
+          - 'babel-jest'
       eslint:
         patterns:
           - 'eslint'
@@ -18,6 +20,8 @@ updates:
           - '@eslint/*'
       jest:
         patterns:
+          - '@jest/*'
+          - 'babel-jest'
           - 'jest'
           - 'jest-*'
       react:


### PR DESCRIPTION
This package is published as part of Jest updates, so we want it grouped that way in our PRs. I am also adding the @jest namespace since I know Jest has packages published there as well.