### PR TITLE
Allow babel-loader v10 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack": "^5.2.0"
   },
   "peerDependencies": {
-    "babel-loader": "^7.0.0 || ^8.0.0 || ^9.0.0",
+    "babel-loader": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "webpack": "^3.5.5 || ^4.0.0 || ^5.0.0"
   },
   "packageManager": "yarn@1.22.22"


### PR DESCRIPTION
This should have been updated when babel-loader v10 was published in February.