### PR TITLE
Add node 24 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18.16.0', 20, 22]
+        node: ['18.16.0', 20, 22, 24]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Node 24 will hit current LTS soon, and we want to make sure that our code will be working well on this version.